### PR TITLE
DevApp scanner & async job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,4 +77,6 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "webdrivers"
+  gem "mocha"
+  gem "minitest-focus"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,9 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
+    minitest-focus (1.3.1)
+      minitest (>= 4, < 6)
+    mocha (1.13.0)
     msgpack (1.4.4)
     multi_json (1.15.0)
     multipart-post (2.1.1)
@@ -324,6 +327,8 @@ DEPENDENCIES
   google-cloud-storage
   importmap-rails
   jbuilder
+  minitest-focus
+  mocha
   mysql2
   pry
   puma (~> 5.0)

--- a/app/jobs/dev_app_scan_job.rb
+++ b/app/jobs/dev_app_scan_job.rb
@@ -1,0 +1,13 @@
+class DevAppScanJob < ApplicationJob
+  queue_as :default
+
+  def perform(app_number: nil)
+    if app_number
+      DevApp::Scanner.scan_application(app_number)
+    else
+      DevApp::Scanner.latest.each do |d|
+        DevAppScanJob.perform_later(app_number: d[:app_number])
+      end
+    end
+  end
+end

--- a/app/models/dev_app/scanner.rb
+++ b/app/models/dev_app/scanner.rb
@@ -11,7 +11,7 @@ class DevApp::Scanner
 		@data = []
 		sheet.each_row do |row|
       d = {}
-			d[:number] = row["Application Number"]
+			d[:app_number] = row["Application Number"]
       d[:date] = row["Application Date"]
       d[:type] = row["Application Type"]
       d[:road_number] = row["Address Number"]
@@ -30,6 +30,9 @@ class DevApp::Scanner
 
 	def to_a
 		@data.dup
+	end
+
+	def self.scan_application(app_number)
 	end
 
 	def self.latest

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,3 +1,17 @@
+# ┌───────────── minute (0 - 59)
+# │ ┌───────────── hour (0 - 23)
+# │ │ ┌───────────── day of the month (1 - 31)
+# │ │ │ ┌───────────── month (1 - 12)
+# │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday;
+# │ │ │ │ │                                   7 is also Sunday on some systems)
+# │ │ │ │ │
+# │ │ │ │ │
+# * * * * * <command to execute>
+
 ping_job:
    cron: "*/5 * * * *"
    class: "PingJob"
+
+dev_app_scan_job:
+   cron: "0 4 * * *"
+   class: "DevAppScanJob"

--- a/test/jobs/dev_app_scan_job_test.rb
+++ b/test/jobs/dev_app_scan_job_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class DevAppScanJobTest < ActiveJob::TestCase
+  test "with no arguments, job runs in enqueuing mode" do
+    DevApp::Scanner.expects(:latest).returns([{app_number: "D07-12-15-0115"}])
+    #DevApp::Scanner.expects(:scan_application).with("D07-12-15-0115")
+    assert_enqueued_with(job: DevAppScanJob) do
+      DevAppScanJob.perform_now
+    end
+  end
+
+  test "with specified app_number, job deep processes just that application" do
+    DevApp::Scanner.expects(:latest).never
+    DevApp::Scanner.expects(:scan_application).with("D07-12-15-0115")
+    DevAppScanJob.perform_now(app_number: "D07-12-15-0115")
+  end
+end

--- a/test/models/dev_app/scanner_test.rb
+++ b/test/models/dev_app/scanner_test.rb
@@ -11,21 +11,20 @@ class DevApp::ScannerTest < ActiveSupport::TestCase
 
   test "structure of open data entries" do
     expected = [
-      "Application Number",
-      "Application Date",
-      "Application Type",
-      "Address Number",
-      "Road Name",
-      "Road Type",
-      "Object Status Type",
-      "Application Status",
-      "File Lead",
-      "Brief Description",
-      "Object Status Date",
-      "Ward #",
-      "Ward",
+      :app_number
+      :date
+      :type
+      :road_number
+      :road_name
+      :road_type
+      :status_type
+      :status
+      :file_lead
+      :description
+      :status_date
+      :ward_num
+      :ward_name
     ]
-    expected = [:number, :date, :type, :road_number, :road_name, :road_type, :status_type, :status, :file_lead, :description, :status_date, :ward_num, :ward_name]
     assert @scanner.to_a.all?{|d| expected == d.keys}
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,9 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
 
+require "minitest/unit"
+require "mocha/minitest"
+
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
   parallelize(workers: :number_of_processors)


### PR DESCRIPTION
No meat yet, but the scaffolding to:

- a job that runs once a day
- it queries the city for the XSLS file that contains all dev apps on record
- enqueues followup jobs, one per row, to dig further on all the details of individual applications

Also added some testing framework details: 

- mocha for mocking 
- focus for faster development; by being able to `focus` (duh!) on just a subset of tests at a time