### PR TITLE
scan individual application into the DB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ group :development do
   # gem "rack-mini-profiler"
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
-  # gem "spring"
+  gem "spring"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,6 +277,7 @@ GEM
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
+    spring (4.0.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -336,6 +337,7 @@ DEPENDENCIES
   selenium-webdriver
   sidekiq
   sidekiq-cron
+  spring
   sprockets-rails
   sqlite3 (~> 1.4)
   stimulus-rails

--- a/app/models/dev_app.rb
+++ b/app/models/dev_app.rb
@@ -1,2 +1,5 @@
 module DevApp
+  def self.table_name_prefix
+    "dev_app_"
+  end
 end

--- a/app/models/dev_app/entry.rb
+++ b/app/models/dev_app/entry.rb
@@ -1,0 +1,2 @@
+class DevApp::Entry < ApplicationRecord
+end

--- a/app/models/dev_app/scanner.rb
+++ b/app/models/dev_app/scanner.rb
@@ -33,6 +33,23 @@ class DevApp::Scanner
 	end
 
 	def self.scan_application(app_number)
+		url = "https://devapps-restapi.ottawa.ca/devapps/search?authKey=#{authkey}&appStatus=all&searchText=#{app_number}&appType=all&ward=all&bounds=0,0,0,0"
+
+		d = JSON.parse(Net::HTTP.get(URI(url)))
+		data = d["devApps"].first
+
+		attributes = {}
+		attributes[:app_id] = data["devAppId"]
+		attributes[:app_number] = data["applicationNumber"]
+		attributes[:app_type] = data.dig("applicationType","en")
+		# these need to be in a join/array table to track state over time
+		# attributes[:status] = data.dig("applicationStatus", "en")
+		# attributes[:statusDetail] = data.dig("objectStatus", "objectCurrentStatus", "en")
+		# attributes[:foo] = data.dig("objectStatus", "objectCurrentStatusDateYMD")
+		entry = DevApp::Entry.find_by(app_id: data["devAppId"]) || DevApp::Entry.new
+		entry.assign_attributes(attributes)
+		entry.save!
+		entry
 	end
 
 	def self.latest
@@ -48,4 +65,8 @@ class DevApp::Scanner
 	def self.open_data_url
 		"https://devapps-restapi.ottawa.ca/devapps/ExportData"
 	end
+
+	def self.authkey
+    '4r5T2egSmKm5'
+  end
 end

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+load File.expand_path("spring", __dir__)
 APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"
 require "rails/commands"

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+load File.expand_path("spring", __dir__)
 require_relative "../config/boot"
 require "rake"
 Rake.application.run

--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+# This file loads Spring without using loading other gems in the Gemfile, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
+  require "bundler"
+
+  Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem "spring", spring.version
+    require "spring/binstub"
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration

--- a/db/migrate/20220207012208_create_dev_app_entries.rb
+++ b/db/migrate/20220207012208_create_dev_app_entries.rb
@@ -1,0 +1,11 @@
+class CreateDevAppEntries < ActiveRecord::Migration[7.0]
+  def change
+    create_table :dev_app_entries do |t|
+      t.string :app_id
+      t.string :app_number
+      t.string :app_type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_22_130113) do
+ActiveRecord::Schema.define(version: 2022_02_07_012208) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -38,6 +38,14 @@ ActiveRecord::Schema.define(version: 2022_01_22_130113) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "dev_app_entries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "app_id"
+    t.string "app_number"
+    t.string "app_type"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/fixtures/dev_app/entries.yml
+++ b/test/fixtures/dev_app/entries.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/dev_app/entry_test.rb
+++ b/test/models/dev_app/entry_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DevApp::EntryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/dev_app/scanner_test.rb
+++ b/test/models/dev_app/scanner_test.rb
@@ -11,21 +11,33 @@ class DevApp::ScannerTest < ActiveSupport::TestCase
 
   test "structure of open data entries" do
     expected = [
-      :app_number
-      :date
-      :type
-      :road_number
-      :road_name
-      :road_type
-      :status_type
-      :status
-      :file_lead
-      :description
-      :status_date
-      :ward_num
+      :app_number,
+      :date,
+      :type,
+      :road_number,
+      :road_name,
+      :road_type,
+      :status_type,
+      :status,
+      :file_lead,
+      :description,
+      :status_date,
+      :ward_num,
       :ward_name
     ]
     assert @scanner.to_a.all?{|d| expected == d.keys}
+  end
+
+  test "scanning an application generates an entry; 2nd can updates previous entry" do
+    entry = assert_difference -> { DevApp::Entry.all.count} do
+      DevApp::Scanner.scan_application("D07-12-22-0010")
+    end
+    entry.update!(app_type: "foo")
+    assert_no_difference -> { DevApp::Entry.all.count} do
+      assert_changes -> { entry.reload.app_type }, from: "foo", to: "Site Plan Control" do
+        DevApp::Scanner.scan_application("D07-12-22-0010")
+      end
+    end
   end
 
   private


### PR DESCRIPTION
Actually do something in the DB when scanning individual applications: 

- `DevApp::Entry` as the main record for a dev app
- save just the basics for each devapp; other fields are ignored for now

