### PR TITLE
consume files related to devapps

### DIFF
--- a/app/models/dev_app/document.rb
+++ b/app/models/dev_app/document.rb
@@ -1,0 +1,3 @@
+class DevApp::Document < ApplicationRecord
+  belongs_to :entry, class_name: "DevApp::Entry", foreign_key: "entry_id"
+end

--- a/app/models/dev_app/entry.rb
+++ b/app/models/dev_app/entry.rb
@@ -1,3 +1,4 @@
 class DevApp::Entry < ApplicationRecord
   has_many :addresses, class_name: "DevApp::Address"
+  has_many :documents, class_name: "DevApp::Document"
 end

--- a/db/migrate/20220209221445_create_dev_app_documents.rb
+++ b/db/migrate/20220209221445_create_dev_app_documents.rb
@@ -1,0 +1,13 @@
+class CreateDevAppDocuments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :dev_app_documents do |t|
+      t.references :entry, null: false, foreign_key: true, class_name: "DevApp::Entry", foreign_key: {to_table: :dev_app_entries}
+      t.string :ref_id
+      t.string :name
+      t.string :path
+      t.string :url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_08_170430) do
+ActiveRecord::Schema.define(version: 2022_02_09_221445) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -59,6 +59,17 @@ ActiveRecord::Schema.define(version: 2022_02_08_170430) do
     t.index ["entry_id"], name: "index_dev_app_addresses_on_entry_id"
   end
 
+  create_table "dev_app_documents", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "entry_id", null: false
+    t.string "ref_id"
+    t.string "name"
+    t.string "path"
+    t.string "url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["entry_id"], name: "index_dev_app_documents_on_entry_id"
+  end
+
   create_table "dev_app_entries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "app_id"
     t.string "app_number"
@@ -69,4 +80,5 @@ ActiveRecord::Schema.define(version: 2022_02_08_170430) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "dev_app_documents", "dev_app_entries", column: "entry_id"
 end

--- a/test/fixtures/dev_app/documents.yml
+++ b/test/fixtures/dev_app/documents.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  entry: one
+  ref_id: MyString
+  name: MyString
+  path: MyString
+  url: MyString
+
+two:
+  entry: two
+  ref_id: MyString
+  name: MyString
+  path: MyString
+  url: MyString

--- a/test/models/dev_app/document_test.rb
+++ b/test/models/dev_app/document_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DevApp::DocumentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/dev_app/scanner_test.rb
+++ b/test/models/dev_app/scanner_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class DevApp::ScannerTest < ActiveSupport::TestCase
+
+  APP_NUMBER = "D07-12-15-0017"
   setup do
     @scanner = DevApp::Scanner.new(cached_devapps_file)
   end
@@ -30,19 +32,25 @@ class DevApp::ScannerTest < ActiveSupport::TestCase
 
   test "scanning an application generates an entry; 2nd can updates previous entry" do
     entry = assert_difference -> { DevApp::Entry.all.count} do
-      DevApp::Scanner.scan_application("D07-12-22-0010")
+      DevApp::Scanner.scan_application(APP_NUMBER)
     end
     entry.update!(app_type: "foo")
     assert_no_difference -> { DevApp::Entry.all.count} do
       assert_changes -> { entry.reload.app_type }, from: "foo", to: "Site Plan Control" do
-        DevApp::Scanner.scan_application("D07-12-22-0010")
+        DevApp::Scanner.scan_application(APP_NUMBER)
       end
     end
   end
 
   test "addresses get saved" do
-    assert_difference -> { DevApp::Address.all.count}, 35 do
-      DevApp::Scanner.scan_application("D07-12-20-0186")
+    assert_difference -> { DevApp::Address.all.count}, 1 do
+      entry = DevApp::Scanner.scan_application(APP_NUMBER)
+    end
+  end
+
+  test "files get saved" do
+    assert_difference -> { DevApp::Document.all.count}, 10 do
+      DevApp::Scanner.scan_application(APP_NUMBER)
     end
   end
 


### PR DESCRIPTION
DevApps come with files attached. Suck in the files.

After this, I'll add ActiveStorage support for the files themselves, and OttWatch will retain a copy of every file, so nothing ever goes missing.