### PR TITLE
Dev app status

### DIFF
--- a/app/models/dev_app/entry.rb
+++ b/app/models/dev_app/entry.rb
@@ -1,4 +1,9 @@
 class DevApp::Entry < ApplicationRecord
+  has_many :statuses, class_name: "DevApp::Status"
   has_many :addresses, class_name: "DevApp::Address"
   has_many :documents, class_name: "DevApp::Document"
+
+  def current_status
+    statuses.order(:id).last
+  end
 end

--- a/app/models/dev_app/scanner.rb
+++ b/app/models/dev_app/scanner.rb
@@ -87,7 +87,12 @@ class DevApp::Scanner
 			entry.desc = desc
 			entry.save!
 
-			# data.dig("applicationStatus", "en")
+			status = data.dig("applicationStatus", "en")
+			if current_status = entry.current_status
+				entry.statuses << DevApp::Status.new(status: status) unless current_status.status == status
+			else
+				entry.statuses << DevApp::Status.new(status: status)
+			end
 
 			data["devAppDocuments"].each do |doc|
 				url = "http://webcast.ottawa.ca/plan/All_Image%20Referencing_#{URI.escape(doc["filePath"])}"

--- a/app/models/dev_app/scanner.rb
+++ b/app/models/dev_app/scanner.rb
@@ -82,8 +82,14 @@ class DevApp::Scanner
 			# file level data isn't in the search results; so hit the other api endpoint
 			url = "https://devapps-restapi.ottawa.ca/devapps/#{app_number}?authKey=#{authkey}"
 			data = JSON.parse(Net::HTTP.get(URI(url)))
+
+			desc = data.dig("applicationBriefDesc", "en")
+			entry.desc = desc
+			entry.save!
+
+			# data.dig("applicationStatus", "en")
+
 			data["devAppDocuments"].each do |doc|
-				
 				url = "http://webcast.ottawa.ca/plan/All_Image%20Referencing_#{URI.escape(doc["filePath"])}"
 				# content = Net::HTTP.get(URI(url)) # downnload file content itself
 				

--- a/app/models/dev_app/status.rb
+++ b/app/models/dev_app/status.rb
@@ -1,0 +1,3 @@
+class DevApp::Status < ApplicationRecord
+  belongs_to :entry, class_name: "DevApp::Entry"
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -5,7 +5,7 @@
 Version: <%= Version.current %><br/>
 <br/>
 Time: <%= Time.now.utc %><br/>
+<br/>
+<%= link_to "Development Applications", devapp_index_path %>
 </center>
 </div>
-
-<%= link_to "Development Applications", devapp_index_path %>

--- a/db/migrate/20220211193125_add_desc_to_dev_app_entry.rb
+++ b/db/migrate/20220211193125_add_desc_to_dev_app_entry.rb
@@ -1,0 +1,5 @@
+class AddDescToDevAppEntry < ActiveRecord::Migration[7.0]
+  def change
+    add_column(:dev_app_entries, :desc, :string)
+  end
+end

--- a/db/migrate/20220211193615_create_dev_app_statuses.rb
+++ b/db/migrate/20220211193615_create_dev_app_statuses.rb
@@ -1,0 +1,10 @@
+class CreateDevAppStatuses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :dev_app_statuses do |t|
+      t.references :entry, null: false, foreign_key: true, class_name: "DevApp::Entry", foreign_key: {to_table: :dev_app_entries}
+      t.string :status
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_11_193125) do
+ActiveRecord::Schema.define(version: 2022_02_11_193615) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -79,7 +79,16 @@ ActiveRecord::Schema.define(version: 2022_02_11_193125) do
     t.string "desc"
   end
 
+  create_table "dev_app_statuses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "entry_id", null: false
+    t.string "status"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["entry_id"], name: "index_dev_app_statuses_on_entry_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "dev_app_documents", "dev_app_entries", column: "entry_id"
+  add_foreign_key "dev_app_statuses", "dev_app_entries", column: "entry_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_09_221445) do
+ActiveRecord::Schema.define(version: 2022_02_11_193125) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2022_02_09_221445) do
     t.string "app_type"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "desc"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/fixtures/dev_app/statuses.yml
+++ b/test/fixtures/dev_app/statuses.yml
@@ -1,0 +1,7 @@
+one:
+  entry: :one
+  status: Active
+
+two:
+  entry: :two
+  status: Inactive

--- a/test/models/dev_app/scanner_test.rb
+++ b/test/models/dev_app/scanner_test.rb
@@ -48,6 +48,21 @@ class DevApp::ScannerTest < ActiveSupport::TestCase
     end
   end
 
+  test "status gets saved" do
+    entry = assert_difference -> { DevApp::Status.all.count}, 1 do
+      DevApp::Scanner.scan_application(APP_NUMBER)
+    end
+    # double-read of same status does not insert duplicate
+    assert_no_difference -> { DevApp::Status.all.count} do
+      DevApp::Scanner.scan_application(APP_NUMBER)
+    end
+    # but additional statuses are tracked when they change
+    entry.reload.current_status.update!(status: "fake state")
+    assert_difference -> { DevApp::Status.all.count}, 1 do
+      DevApp::Scanner.scan_application(APP_NUMBER)
+    end
+  end
+
   test "files get saved" do
     assert_difference -> { DevApp::Document.all.count}, 10 do
       DevApp::Scanner.scan_application(APP_NUMBER)

--- a/test/models/dev_app/status_test.rb
+++ b/test/models/dev_app/status_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DevApp::StatusTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
The city's data doesn't include a timeline of how devapps go through their lifecycle, so we'll track that.

Each time we scan a dev_app, save a new `status` record if it is different than the previous one. 

We scan all devapps every four hours, so this'll be nicely tracked as a timeline.