### PR TITLE
Announce state changes for DevApps

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,3 @@
+class Announcement < ApplicationRecord
+  belongs_to :reference, polymorphic: true
+end

--- a/app/models/dev_app/entry.rb
+++ b/app/models/dev_app/entry.rb
@@ -2,6 +2,7 @@ class DevApp::Entry < ApplicationRecord
   has_many :statuses, class_name: "DevApp::Status"
   has_many :addresses, class_name: "DevApp::Address"
   has_many :documents, class_name: "DevApp::Document"
+  has_many :announcements, as: :reference
 
   def current_status
     statuses.order(:id).last

--- a/db/migrate/20220212131300_create_announcements.rb
+++ b/db/migrate/20220212131300_create_announcements.rb
@@ -1,0 +1,11 @@
+class CreateAnnouncements < ActiveRecord::Migration[7.0]
+  def change
+    create_table :announcements do |t|
+      t.string :message
+      t.bigint :reference_id
+      t.string :reference_type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_11_193615) do
+ActiveRecord::Schema.define(version: 2022_02_12_131300) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -38,6 +38,14 @@ ActiveRecord::Schema.define(version: 2022_02_11_193615) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "announcements", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "message"
+    t.bigint "reference_id"
+    t.string "reference_type"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "dev_app_addresses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/test/fixtures/announcements.yml
+++ b/test/fixtures/announcements.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  message: MyString
+  reference_id: 
+  reference_type: MyString
+
+two:
+  message: MyString
+  reference_id: 
+  reference_type: MyString

--- a/test/models/announcement_test.rb
+++ b/test/models/announcement_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AnnouncementTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/dev_app/scanner_test.rb
+++ b/test/models/dev_app/scanner_test.rb
@@ -42,6 +42,26 @@ class DevApp::ScannerTest < ActiveSupport::TestCase
     end
   end
 
+  test "new devapp is announced as new" do
+    entry = assert_difference -> { Announcement.all.count} do
+      DevApp::Scanner.scan_application(APP_NUMBER)
+    end
+    announcement = Announcement.last
+    assert_equal "New DevApp: D07-12-15-0017", announcement.message
+  end
+
+  test "devapp status changes are announced" do
+    entry = DevApp::Scanner.scan_application(APP_NUMBER)
+    s = entry.statuses.first
+    s.status = "fake"
+    s.save!
+    entry = assert_difference -> { Announcement.all.count} do
+      DevApp::Scanner.scan_application(APP_NUMBER)
+    end
+    announcement = Announcement.last
+    assert_equal "DevApp D07-12-15-0017 changed status from fake to Active", announcement.message
+  end
+
   test "addresses get saved" do
     assert_difference -> { DevApp::Address.all.count}, 1 do
       entry = DevApp::Scanner.scan_application(APP_NUMBER)


### PR DESCRIPTION
- new `Announcement` model, which will drive syndication operations
- can reference any thing, DevApp for starters
- just announce "message" and "reference"; leave URL and syndcation to a later step