### PR TITLE
Job that syndicates announcements

### DIFF
--- a/app/jobs/syndication_job.rb
+++ b/app/jobs/syndication_job.rb
@@ -1,0 +1,23 @@
+class SyndicationJob < ApplicationJob
+  queue_as :default
+
+  GLOBAL_CONFIG_KEY = "syndication_job_last_id"
+
+  def syndicate(a)
+    TwitterClient.update(a.message)
+  end
+
+  def perform
+    announcements.each do |a|
+      GlobalControl.set(GLOBAL_CONFIG_KEY, a.id)
+      syndicate(a)
+    end
+  end
+
+  private
+
+  def announcements
+    last_id = GlobalControl.get(GLOBAL_CONFIG_KEY) || 0
+    Announcement.where('id > ?', last_id).order(:id).limit(5)
+  end
+end

--- a/app/models/twitter_client.rb
+++ b/app/models/twitter_client.rb
@@ -1,14 +1,30 @@
 class TwitterClient
   def initialize
-    @client = Twitter::REST::Client.new do |config|
-      config.consumer_key = ENV.fetch("TWITTER_POST_CONSUMER_KEY")
-      config.consumer_secret = ENV.fetch("TWITTER_POST_CONSUMER_SECRET")
-      config.access_token = ENV.fetch("TWITTER_POST_ACCESS_TOKEN")
-      config.access_token_secret = ENV.fetch("TWITTER_POST_TOKEN_SECRET")
+  end
+
+  def self.update(message)
+    client.update(message)
+  end
+
+  def self.client
+    if Rails.env.production?
+      Twitter::REST::Client.new do |config|
+        config.consumer_key = ENV.fetch("TWITTER_POST_CONSUMER_KEY")
+        config.consumer_secret = ENV.fetch("TWITTER_POST_CONSUMER_SECRET")
+        config.access_token = ENV.fetch("TWITTER_POST_ACCESS_TOKEN")
+        config.access_token_secret = ENV.fetch("TWITTER_POST_TOKEN_SECRET")
+      end
+    else
+      MockTwitterClient.new
     end
   end
 
-  def client
-    @client
+  private
+
+  class MockTwitterClient
+    def update(message)
+      # puts "#### SENDING TWEET: #{message}"
+      # noop
+    end
   end
 end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -15,3 +15,7 @@ ping_job:
 dev_app_scan_job:
    cron: "0 */4 * * *"
    class: "DevAppScanJob"
+
+# syndication_job:
+#    cron: "0/5 * * * *"
+#    class: "SyndicationJob"

--- a/test/fixtures/announcements.yml
+++ b/test/fixtures/announcements.yml
@@ -1,11 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  message: MyString
+  message: This is an announcement
   reference_id: 
   reference_type: MyString
 
 two:
-  message: MyString
+  message: This is another announcement
   reference_id: 
   reference_type: MyString

--- a/test/jobs/syndication_job_test.rb
+++ b/test/jobs/syndication_job_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class SyndicationJobTest < ActiveJob::TestCase
+  test "syndication job updates last_id pointer" do
+    assert_changes -> { GlobalControl.get("syndication_job_last_id") }, from: nil, to: Announcement.last.id.to_s do
+      SyndicationJob.perform_now
+    end
+  end
+
+  test "syndication job does not double announce" do
+    SyndicationJob.any_instance.expects(:syndicate).times(2)
+    SyndicationJob.perform_now
+    SyndicationJob.any_instance.expects(:syndicate).times(0)
+    SyndicationJob.perform_now
+  end
+
+  test "syndication job sends one tweet per announcement" do
+    TwitterClient.expects(:update).times(Announcement.count)
+    SyndicationJob.perform_now
+  end
+end


### PR DESCRIPTION
The main system will produce `announcement` records at the appropriate time.

This PR adds a job that finds each announcement, according to a cursor, and sends it to twitter