### PR TITLE
HTTP HEAD operation on all devapp docs during scan

### DIFF
--- a/app/models/dev_app/scanner.rb
+++ b/app/models/dev_app/scanner.rb
@@ -119,6 +119,16 @@ class DevApp::Scanner
           url: url
         }
 
+        begin
+          uri = URI(attributes[:url])
+          Net::HTTP.start(uri.host, uri.port) do |http|
+            response = http.head(uri.path)
+            attributes[:state] = response.code
+          end
+        rescue => e
+          Rails.logger.warn("error on HTTP HEAD for #{attributes[:url]}; #{e.message}")
+        end
+
         doc = DevApp::Document.find_by(ref_id: attributes[:ref_id], entry: entry) || DevApp::Document.new
         doc.assign_attributes(attributes)
         doc.entry = entry

--- a/db/migrate/20220409210514_add_state_to_dev_app_documents.rb
+++ b/db/migrate/20220409210514_add_state_to_dev_app_documents.rb
@@ -1,0 +1,5 @@
+class AddStateToDevAppDocuments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :dev_app_documents, :state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_03_190017) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_09_210514) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -74,6 +74,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_03_190017) do
     t.string "url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "state"
     t.index ["entry_id"], name: "index_dev_app_documents_on_entry_id"
   end
 

--- a/fixtures/vcr_cassettes/DevApp_ScannerTest_test_documents_are_checked_for_404_result.yml
+++ b/fixtures/vcr_cassettes/DevApp_ScannerTest_test_documents_are_checked_for_404_result.yml
@@ -1,0 +1,1239 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://devapps-restapi.ottawa.ca/devapps/search?appStatus=all&appType=all&authKey=4r5T2egSmKm5&bounds=0,0,0,0&searchText=D07-12-21-0040&ward=all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - devapps-restapi.ottawa.ca
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 09 Apr 2022 21:10:37 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ott-Cache:
+      - '10'
+      Set-Cookie:
+      - NSC_QH_NzTP_ohjoy=ffffffffc3a0bc3845525d5f4f58455e445a4a42378b;expires=Sat,
+        09-Apr-2022 21:40:37 GMT;path=/;httponly
+      - incap_ses_305_2348304=iEUWO1Bvblpw3YQ7E5Q7BEz2UWIAAAAAdkpLBSwKx0nmwDRIU8AEEA==;
+        path=/; Domain=.ottawa.ca
+      - nlbi_2348304=CmMwJ49yFw/ZexcMl2uJLQAAAAD3EuaV5717eW+MYWoS18u7; path=/; Domain=.ottawa.ca
+      - visid_incap_2348304=9lhmvppfTCu0E9qc7o42i0z2UWIAAAAAQUIPAAAAAABU3LM0x6yViqeZmLSLXTkn;
+        expires=Sun, 09 Apr 2023 09:10:47 GMT; HttpOnly; path=/; Domain=.ottawa.ca
+      X-Cdn:
+      - Imperva
+      X-Iinfo:
+      - 11-99839579-99839598 NNYN CT(11 41 0) RT(1649538636402 63) q(0 0 1 -1) r(2
+        2) U5
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJkZXZBcHBzIjpbeyJkZXZBcHBJZCI6Il9fQkRENDVBIiwiYXBwbGljYXRpb25OdW1iZXIiOiJEMDctMTItMjEtMDA0MCIsImFwcGxpY2F0aW9uRGF0ZSI6NjM3NTI2MTg0MTAwMDAwMDAwLCJhcHBsaWNhdGlvbkRhdGVZTUQiOiIyMDIxLTAzLTI5IiwiYXBwbGljYXRpb25UeXBlSWQiOiJfX19fNUNDViIsImFwcGxpY2F0aW9uVHlwZSI6eyJlbiI6IlNpdGUgUGxhbiBDb250cm9sIiwiZnIiOiJSw6lnbGVtZW50YXRpb24gZHUgcGxhbiBkJ2ltcGxhbnRhdGlvbiJ9LCJhcHBsaWNhdGlvbkJyaWVmRGVzYyI6e30sImFwcGxpY2F0aW9uU3RhdHVzIjp7ImVuIjoiQWN0aXZlIiwiZnIiOiJBY3RpZiJ9LCJkZXZBcHBBZGRyZXNzZXMiOlt7ImFkZHJlc3NSZWZlcmVuY2VJZCI6Il9fQkRENEM4IiwiYWRkcmVzc051bWJlciI6MjE2LCJhZGRyZXNzUXVhbGlmaWVyIjoiIiwibGVnYWxVbml0IjoiIiwicm9hZE5hbWUiOiJNVVJSQVkiLCJjYXJkaW5hbERpcmVjdGlvbiI6IiIsInJvYWRUeXBlIjoiU3RyZWV0IiwibXVuaWNpcGFsaXR5IjoiT2xkIE90dGF3YSIsImFkZHJlc3NUeXBlIjoiTUFJTiIsImFkZHJlc3NMYXRpdHVkZSI6NDUuNDMxMjYzLCJhZGRyZXNzTG9uZ2l0dWRlIjotNzUuNjg5MjQyLCJhZGRyZXNzTnVtYmVyUm9hZE5hbWUiOiIyMTYgTVVSUkFZIiwicGFyY2VsUGluTnVtYmVyIjo0MjE0MDA1Mn1dLCJkZXZBcHBEb2N1bWVudHMiOltdLCJvYmplY3RTdGF0dXMiOnsib2JqZWN0U3RhdHVzVHlwZUlkIjoiX180TzM4UjIiLCJvYmplY3RDdXJyZW50U3RhdHVzIjp7ImVuIjoiUmVjZWlwdCBvZiBMZXR0ZXIgb2YgVW5kZXJ0YWtpbmcgZnJvbSBPd25lciBQZW5kaW5nIiwiZnIiOiJFbiBBdHRlbnRlIGRlIGxhIFLDqWNlcHRpb24gZGUgbGEgTGV0dHJlIEQnZW5nYWdlbWVudCBkdSBQcm9wcmnDqXRhaXJlIn0sIm9iamVjdEN1cnJlbnRTdGF0dXNEYXRlIjo2Mzc4NDY5MDg5NjAwMDAwMDAsIm9iamVjdEN1cnJlbnRTdGF0dXNEYXRlWU1EIjoiMjAyMi0wNC0wNCJ9LCJkZXZBcHBXYXJkIjp7ImNvbW11bml0eUlkIjpudWxsLCJ3YXJkTnVtYmVyIjp7fSwid2FyZE5hbWUiOnt9LCJjb3VuY2lsbG9yTGFzdE5hbWUiOm51bGwsImNvdW5jaWxsb3JGaXJzdE5hbWUiOm51bGwsIndhcmRDb3VuY2lsbG9yRW1haWwiOm51bGx9LCJlbmRPZkNpcmN1bGF0aW9uRGF0ZSI6MCwiZW5kT2ZDaXJjdWxhdGlvbkRhdGVZTUQiOiIwMDAxLTAxLTAxIiwiY2FuQ29tbWVudCI6IlkiLCJzaG93RmVlZGJhY2tMaW5rIjoiTiIsInBsYW5uZXJGaXJzdE5hbWUiOm51bGwsInBsYW5uZXJMYXN0TmFtZSI6bnVsbCwicGxhbm5lclBob25lIjpudWxsLCJwbGFubmVyRW1haWwiOm51bGwsInNlYXJjaGFibGVUZXh0IjpudWxsLCJzdHJlZXRBZHJlc3MiOiJNVVJSQVkiLCJzdHJlZXROdW1iZXIiOjIxNn1dLCJ0b3RhbERldkFwcHMiOjEsImluZGV4IjowLCJsaW1pdCI6NTB9
+  recorded_at: Sat, 09 Apr 2022 21:10:37 GMT
+- request:
+    method: get
+    uri: https://devapps-restapi.ottawa.ca/devapps/D07-12-21-0040?authKey=4r5T2egSmKm5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - devapps-restapi.ottawa.ca
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 09 Apr 2022 21:10:37 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ott-Cache:
+      - '10'
+      Set-Cookie:
+      - NSC_QH_NzTP_ohjoy=ffffffffc3a0bc3845525d5f4f58455e445a4a42378b;expires=Sat,
+        09-Apr-2022 21:40:37 GMT;path=/;httponly
+      - incap_ses_305_2348304=VhYkWETeuEal3YQ7E5Q7BEz2UWIAAAAAQIo3NRlMt7d/5t3Wvjr+Tw==;
+        path=/; Domain=.ottawa.ca
+      - nlbi_2348304=zPPKNrmN9TJ8Qc6yl2uJLQAAAAAOspLvK9C421n5/mA073s3; path=/; Domain=.ottawa.ca
+      - visid_incap_2348304=/MnBSlouR6i5Uk2P2WOzYUz2UWIAAAAAQUIPAAAAAABKMjAOgdL5z6HrV0Kntb+4;
+        expires=Sun, 09 Apr 2023 09:10:47 GMT; HttpOnly; path=/; Domain=.ottawa.ca
+      X-Cdn:
+      - Imperva
+      X-Iinfo:
+      - 13-155012074-155012093 NNYY CT(12 39 0) RT(1649538636826 68) q(0 0 0 -1) r(1
+        1) U5
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJkZXZBcHBJZCI6Il9fQkRENDVBIiwiYXBwbGljYXRpb25OdW1iZXIiOiJEMDctMTItMjEtMDA0MCIsImFwcGxpY2F0aW9uRGF0ZSI6NjM3NTI2MTg0MTAwMDAwMDAwLCJhcHBsaWNhdGlvbkRhdGVZTUQiOiIyMDIxLTAzLTI5IiwiYXBwbGljYXRpb25UeXBlSWQiOiJfX19fNUNDViIsImFwcGxpY2F0aW9uVHlwZSI6eyJlbiI6IlNpdGUgUGxhbiBDb250cm9sIiwiZnIiOiJSw6lnbGVtZW50YXRpb24gZHUgcGxhbiBkJ2ltcGxhbnRhdGlvbiJ9LCJhcHBsaWNhdGlvbkJyaWVmRGVzYyI6eyJlbiI6IlRoZSBDaXR5IG9mIE90dGF3YSBoYXMgcmVjZWl2ZWQgWm9uaW5nIEJ5LWxhdyBBbWVuZG1lbnQgYW5kIFNpdGUgUGxhbiBDb250cm9sIGFwcGxpY2F0aW9ucyB0byBwZXJtaXQgdGhlIGRldmVsb3BtZW50IG9mIGFuIDgtc3RvcmV5IG1peGVkLXVzZSBidWlsZGluZyB3aXRoIDQ4IGR3ZWxsaW5nIHVuaXRzIG9uIGZsb29ycyB0aHJlZSB0byBlaWdodCwgYW5kIGEgY29tbXVuaXR5IGhlYWx0aCBhbmQgcmVzb3VyY2UgY2VudHJlIHRoYXQgaW5jbHVkZXMgYSBsb3ctYmFycmllciBkcm9wLWluIGNlbnRyZSBhbmQgY29tbWVyY2lhbCBraXRjaGVuIGF0IGdyYWRlIGFuZCBvbiB0aGUgc2Vjb25kIGZsb29yLiIsImZyIjoiTGEgVmlsbGUgZCdPdHRhd2EgYSByZcOndSBkZXMgZGVtYW5kZXMgZGUgbW9kaWZpY2F0aW9uIGR1IFLDqGdsZW1lbnQgZGUgem9uYWdlIGV0IGRlIHLDqWdsZW1lbnRhdGlvbiBkdSBwbGFuIGQnaW1wbGFudGF0aW9uIHZpc2FudCDDoCBwZXJtZXR0cmUgbGEgY29uc3RydWN0aW9uIGQndW4gaW1tZXVibGUgcG9seXZhbGVudCBkZSBodWl0IMOpdGFnZXMgYWJyaXRhbnQgNDggbG9nZW1lbnRzIGR1IHRyb2lzacOobWUgYXUgaHVpdGnDqG1lIMOpdGFnZSwgYWluc2kgcXUndW4gY2VudHJlIGRlIHJlc3NvdXJjZXMgZXQgZGUgc2FudMOpIGNvbW11bmF1dGFpcmUgY29tcHJlbmFudCB1bmUgaGFsdGUtZ2FyZGVyaWUgc2FucyBvYnN0YWNsZSBldCB1bmUgY3Vpc2luZSBjb21tZXJjaWFsZSBhdSByZXotZGUtY2hhdXNzw6llIGV0IGF1IGRldXhpw6htZSDDqXRhZ2UuIn0sImFwcGxpY2F0aW9uU3RhdHVzIjp7ImVuIjoiQWN0aXZlIiwiZnIiOiJBY3RpZiJ9LCJkZXZBcHBBZGRyZXNzZXMiOlt7ImFkZHJlc3NSZWZlcmVuY2VJZCI6Il9fQkRENEM4IiwiYWRkcmVzc051bWJlciI6MjE2LCJhZGRyZXNzUXVhbGlmaWVyIjoiIiwibGVnYWxVbml0IjoiIiwicm9hZE5hbWUiOiJNVVJSQVkiLCJjYXJkaW5hbERpcmVjdGlvbiI6IiIsInJvYWRUeXBlIjoiU3RyZWV0IiwibXVuaWNpcGFsaXR5IjoiT2xkIE90dGF3YSIsImFkZHJlc3NUeXBlIjoiTUFJTiIsImFkZHJlc3NMYXRpdHVkZSI6NDUuNDMxMjYzLCJhZGRyZXNzTG9uZ2l0dWRlIjotNzUuNjg5MjQyLCJhZGRyZXNzTnVtYmVyUm9hZE5hbWUiOiIyMTYgTVVSUkFZIiwicGFyY2VsUGluTnVtYmVyIjo0MjE0MDA1Mn1dLCJkZXZBcHBEb2N1bWVudHMiOlt7ImRvY1JlZmVyZW5jZUlkIjoiX19DS0pWRUkiLCJkb2N1bWVudE5hbWUiOiIyMDIyLTA0LTAxIC0gU2lnbmVkIERlbGVnYXRlZCBBdXRob3JpdHkgUmVwb3J0IC0gRDA3LTEyLTIxLTAwNDAiLCJmaWxlU2l6ZSI6IjAuNzQgTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMi0wNC0wMSAtIFNpZ25lZCBEZWxlZ2F0ZWQgQXV0aG9yaXR5IFJlcG9ydCAtIEQwNy0xMi0yMS0wMDQwLlBERiJ9LHsiZG9jUmVmZXJlbmNlSWQiOiJfX0NLSlZEQSIsImRvY3VtZW50TmFtZSI6IjIwMjItMDQtMDEgLSBBcHByb3ZlZCBUcmVlIENvbnNlcnZhdGlvbiBSZXBvcnQgYW5kIExhbmRzY2FwZSBQbGFuIC0gRDA3LTEyLTIxLTAwNDAiLCJmaWxlU2l6ZSI6IjEuMDQgTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMi0wNC0wMSAtIEFwcHJvdmVkIFRyZWUgQ29uc2VydmF0aW9uIFJlcG9ydCBhbmQgTGFuZHNjYXBlIFBsYW4gLSBEMDctMTItMjEtMDA0MC5QREYifSx7ImRvY1JlZmVyZW5jZUlkIjoiX19DS0pWRDEiLCJkb2N1bWVudE5hbWUiOiIyMDIyLTA0LTAxIC0gQXBwcm92ZWQgUmVtb3ZhbHMsIFNpdGUgU2VydmljaW5nLCBMb3QgR3JhZGluZywgRHJhaW5hZ2UsIFNlZGltZW50ICYgRXJvc2lvbiBDb250cm9sIiwiZmlsZVNpemUiOiIyLjM4IE1CIiwiZmlsZVBhdGgiOiJTaXRlIFBsYW4gQXBwbGljYXRpb25fSW1hZ2UgUmVmZXJlbmNlXzIwMjItMDQtMDEgLSBBcHByb3ZlZCBSZW1vdmFscywgU2l0ZSBTZXJ2aWNpbmcsIExvdCBHcmFkaW5nLCBEcmFpbmFnZSwgU2VkaW1lbnQgJiBFcm9zaW9uIENvbnRyb2wuUERGIn0seyJkb2NSZWZlcmVuY2VJZCI6Il9fQ0tKVkRLIiwiZG9jdW1lbnROYW1lIjoiMjAyMi0wNC0wMSAtIEFwcHJvdmVkIE92ZXJhbGwgU2l0ZSBQbGFuIC0gRDA3LTEyLTIxLTAwNDAiLCJmaWxlU2l6ZSI6IjAuMzggTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMi0wNC0wMSAtIEFwcHJvdmVkIE92ZXJhbGwgU2l0ZSBQbGFuIC0gRDA3LTEyLTIxLTAwNDAuUERGIn0seyJkb2NSZWZlcmVuY2VJZCI6Il9fQ0tKVkNGIiwiZG9jdW1lbnROYW1lIjoiMjAyMi0wNC0wMSAtIEFwcHJvdmVkIE5ldyBTaXRlIFBsYW4gLSBEMDctMTItMjEtMDA0MCIsImZpbGVTaXplIjoiMC4zNCBNQiIsImZpbGVQYXRoIjoiU2l0ZSBQbGFuIEFwcGxpY2F0aW9uX0ltYWdlIFJlZmVyZW5jZV8yMDIyLTA0LTAxIC0gQXBwcm92ZWQgTmV3IFNpdGUgUGxhbiAtIEQwNy0xMi0yMS0wMDQwLlBERiJ9LHsiZG9jUmVmZXJlbmNlSWQiOiJfX0NLSlZDMyIsImRvY3VtZW50TmFtZSI6IjIwMjItMDQtMDEgLSBBcHByb3ZlZCBFbGV2YXRpb25zIC0gRDA3LTEyLTIxLTAwNDAiLCJmaWxlU2l6ZSI6IjEuNTcgTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMi0wNC0wMSAtIEFwcHJvdmVkIEVsZXZhdGlvbnMgLSBEMDctMTItMjEtMDA0MC5QREYifSx7ImRvY1JlZmVyZW5jZUlkIjoiX19DSEtIS0YiLCJkb2N1bWVudE5hbWUiOiIyMDIxLTA5LTE3IC0gU3RhdGlvbmFyeSBOb2lzZSBBc3Nlc3NtZW50IC0gRDA3LTEyLTIxLTAwNDAiLCJmaWxlU2l6ZSI6IjAuODggTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMS0wOS0xNyAtIFN0YXRpb25hcnkgTm9pc2UgQXNzZXNzbWVudCAtIEQwNy0xMi0yMS0wMDQwLlBERiJ9LHsiZG9jUmVmZXJlbmNlSWQiOiJfX0NIS0hISiIsImRvY3VtZW50TmFtZSI6IjIwMjEtMDktMTcgLSBTaXRlIFBsYW4gLSBEMDctMTItMjEtMDA0MCIsImZpbGVTaXplIjoiMC41OSBNQiIsImZpbGVQYXRoIjoiU2l0ZSBQbGFuIEFwcGxpY2F0aW9uX0ltYWdlIFJlZmVyZW5jZV8yMDIxLTA5LTE3IC0gU2l0ZSBQbGFuIC0gRDA3LTEyLTIxLTAwNDAuUERGIn0seyJkb2NSZWZlcmVuY2VJZCI6Il9fQ0hLSEpDIiwiZG9jdW1lbnROYW1lIjoiMjAyMS0wOS0xNyAtIFBoYXNlIFR3byBFbnZpcm9ubWVudGFsIFNpdGUgQXNzZXNzbWVudCAtIEQwNy0xMi0yMS0wMDQwIiwiZmlsZVNpemUiOiIxMS4xMiBNQiIsImZpbGVQYXRoIjoiU2l0ZSBQbGFuIEFwcGxpY2F0aW9uX0ltYWdlIFJlZmVyZW5jZV8yMDIxLTA5LTE3IC0gUGhhc2UgVHdvIEVudmlyb25tZW50YWwgU2l0ZSBBc3Nlc3NtZW50IC0gRDA3LTEyLTIxLTAwNDAuUERGIn0seyJkb2NSZWZlcmVuY2VJZCI6Il9fQ0hLSElQIiwiZG9jdW1lbnROYW1lIjoiMjAyMS0wOS0xNyAtIFBoYXNlIE9uZSBFbnZpcm9ubWVudGFsIFNpdGUgQXNzZXNzbWVudCAtIEQwNy0xMi0yMS0wMDQwIiwiZmlsZVNpemUiOiI0MC44OSBNQiIsImZpbGVQYXRoIjoiU2l0ZSBQbGFuIEFwcGxpY2F0aW9uX0ltYWdlIFJlZmVyZW5jZV8yMDIxLTA5LTE3IC0gUGhhc2UgT25lIEVudmlyb25tZW50YWwgU2l0ZSBBc3Nlc3NtZW50IC0gRDA3LTEyLTIxLTAwNDAuUERGIn0seyJkb2NSZWZlcmVuY2VJZCI6Il9fQ0hLSEgxIiwiZG9jdW1lbnROYW1lIjoiMjAyMS0wOS0xNyAtIEdlb3RlY2huY2lhbCBSZXBvcnQgLSBEMDctMTItMjEtMDA0MCIsImZpbGVTaXplIjoiMTAuNTIgTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMS0wOS0xNyAtIEdlb3RlY2huY2lhbCBSZXBvcnQgLSBEMDctMTItMjEtMDA0MC5QREYifSx7ImRvY1JlZmVyZW5jZUlkIjoiX19CRlMzUlciLCJkb2N1bWVudE5hbWUiOiIyMDIxLTA1LTMxIC0gVHJlZSBDb25zZXJ2YXRpb24gYW5kIExhbmRzY2FwZSBSZXBvcnQgLSBEMDctMTItMjEtMDA0MCIsImZpbGVTaXplIjoiMC45NiBNQiIsImZpbGVQYXRoIjoiU2l0ZSBQbGFuIEFwcGxpY2F0aW9uX0ltYWdlIFJlZmVyZW5jZV8yMDIxLTA1LTMxIC0gVHJlZSBDb25zZXJ2YXRpb24gYW5kIExhbmRzY2FwZSBSZXBvcnQgLSBEMDctMTItMjEtMDA0MC5QREYifSx7ImRvY1JlZmVyZW5jZUlkIjoiX19CRlMzUTgiLCJkb2N1bWVudE5hbWUiOiIyMDIxLTA1LTMxIC0gU2l0ZSBQbGFuIC0gRDA3LTEyLTIxLTAwNDAiLCJmaWxlU2l6ZSI6IjAuNzMgTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMS0wNS0zMSAtIFNpdGUgUGxhbiAtIEQwNy0xMi0yMS0wMDQwLlBERiJ9LHsiZG9jUmVmZXJlbmNlSWQiOiJfX0JGUzNUNCIsImRvY3VtZW50TmFtZSI6IjIwMjEtMDUtMzEgLSBTZXJ2aWNpbmcgYW5kIFN0b3Jtd2F0ZXIgTWFuYWdlbWVudCBSZXBvcnQgLSBEMDctMTItMjEtMDA0MCIsImZpbGVTaXplIjoiMTUuMDAgTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMS0wNS0zMSAtIFNlcnZpY2luZyBhbmQgU3Rvcm13YXRlciBNYW5hZ2VtZW50IFJlcG9ydCAtIEQwNy0xMi0yMS0wMDQwLlBERiJ9LHsiZG9jUmVmZXJlbmNlSWQiOiJfX0JGUzNVQyIsImRvY3VtZW50TmFtZSI6IjIwMjEtMDUtMzEgLSBSZW1vdmFscywgU2l0ZSBTZXJ2aWNpbmcsIEdyYWRpbmcsIEVyb3Npb24gUGxhbiAtIEQwNy0xMi0yMS0wMDQwIiwiZmlsZVNpemUiOiIyLjMxIE1CIiwiZmlsZVBhdGgiOiJTaXRlIFBsYW4gQXBwbGljYXRpb25fSW1hZ2UgUmVmZXJlbmNlXzIwMjEtMDUtMzEgLSBSZW1vdmFscywgU2l0ZSBTZXJ2aWNpbmcsIEdyYWRpbmcsIEVyb3Npb24gUGxhbiAtIEQwNy0xMi0yMS0wMDQwLlBERiJ9LHsiZG9jUmVmZXJlbmNlSWQiOiJfX0JGUzNSTyIsImRvY3VtZW50TmFtZSI6IjIwMjEtMDUtMzEgLSBFbGV2YXRpb25zIC0gRDA3LTEyLTIxLTAwNDAiLCJmaWxlU2l6ZSI6IjEuMzkgTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMS0wNS0zMSAtIEVsZXZhdGlvbnMgLSBEMDctMTItMjEtMDA0MC5QREYifSx7ImRvY1JlZmVyZW5jZUlkIjoiX19CRlMzVjEiLCJkb2N1bWVudE5hbWUiOiIyMDIxLTA1LTMxIC0gQ3VsdHVyYWwgSGVyaXRhZ2UgSW1wYWN0IFN0YXRlbWVudCAtIEQwNy0xMi0yMS0wMDQwIiwiZmlsZVNpemUiOiI2LjQ0IE1CIiwiZmlsZVBhdGgiOiJTaXRlIFBsYW4gQXBwbGljYXRpb25fSW1hZ2UgUmVmZXJlbmNlXzIwMjEtMDUtMzEgLSBDdWx0dXJhbCBIZXJpdGFnZSBJbXBhY3QgU3RhdGVtZW50IC0gRDA3LTEyLTIxLTAwNDAuUERGIn0seyJkb2NSZWZlcmVuY2VJZCI6Il9fQkVLRzY0IiwiZG9jdW1lbnROYW1lIjoiMjAyMS0wNC0wNyAtIEFwcGxpY2F0aW9uIFN1bW1hcnkgYW5kIExvY2F0aW9uIE1hcCAtIEQwNy0xMi0yMS0wMDQwIiwiZmlsZVNpemUiOiIwLjkwIE1CIiwiZmlsZVBhdGgiOiJTaXRlIFBsYW4gQXBwbGljYXRpb25fSW1hZ2UgUmVmZXJlbmNlXzIwMjEtMDQtMDcgLSBBcHBsaWNhdGlvbiBTdW1tYXJ5IGFuZCBMb2NhdGlvbiBNYXAgLSBEMDctMTItMjEtMDA0MC5QREYifSx7ImRvY1JlZmVyZW5jZUlkIjoiX19CRUhVOFIiLCJkb2N1bWVudE5hbWUiOiIyMDIxLTA0LTAxIC0gVURSUCBEZXNpZ24gQnJpZWYgLSBEMDctMTItMjEtMDA0MCIsImZpbGVTaXplIjoiMTcuMTQgTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMS0wNC0wMSAtIFVEUlAgRGVzaWduIEJyaWVmIC0gRDA3LTEyLTIxLTAwNDAuUERGIn0seyJkb2NSZWZlcmVuY2VJZCI6Il9fQkRHUUY5IiwiZG9jdW1lbnROYW1lIjoiMjAyMS0wMy0zMSAtIEdlb3RlY2huY2lhbCBSZXBvcnQgLSBEMDctMTItMjEtMDA0MCIsImZpbGVTaXplIjoiMTAuNDMgTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMS0wMy0zMSAtIEdlb3RlY2huY2lhbCBSZXBvcnQgLSBEMDctMTItMjEtMDA0MC5QREYifSx7ImRvY1JlZmVyZW5jZUlkIjoiX19CREQ2WVgiLCJkb2N1bWVudE5hbWUiOiIyMDIxLTAzLTI5IC0gVHJhbnNwb3J0YXRpb24gSW1wYWN0IE1lbW8gLSBEMDctMTItMjEtMDA0MCIsImZpbGVTaXplIjoiMi4xNiBNQiIsImZpbGVQYXRoIjoiU2l0ZSBQbGFuIEFwcGxpY2F0aW9uX0ltYWdlIFJlZmVyZW5jZV8yMDIxLTAzLTI5IC0gVHJhbnNwb3J0YXRpb24gSW1wYWN0IE1lbW8gLSBEMDctMTItMjEtMDA0MC5QREYifSx7ImRvY1JlZmVyZW5jZUlkIjoiX19CREQ2WDciLCJkb2N1bWVudE5hbWUiOiIyMDIxLTAzLTI5IC0gVHJhZmZpYyBOb2lzZSBBc3Nlc3NtZW50IC0gRDA3LTEyLTIxLTAwNDAiLCJmaWxlU2l6ZSI6IjEuNDAgTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMS0wMy0yOSAtIFRyYWZmaWMgTm9pc2UgQXNzZXNzbWVudCAtIEQwNy0xMi0yMS0wMDQwLlBERiJ9LHsiZG9jUmVmZXJlbmNlSWQiOiJfX0JERDZTUSIsImRvY3VtZW50TmFtZSI6IjIwMjEtMDMtMjkgLSBTaXRlIFBsYW4gLSBEMDctMTItMjEtMDA0MCIsImZpbGVTaXplIjoiMC40NiBNQiIsImZpbGVQYXRoIjoiU2l0ZSBQbGFuIEFwcGxpY2F0aW9uX0ltYWdlIFJlZmVyZW5jZV8yMDIxLTAzLTI5IC0gU2l0ZSBQbGFuIC0gRDA3LTEyLTIxLTAwNDAuUERGIn0seyJkb2NSZWZlcmVuY2VJZCI6Il9fQkRENlJHIiwiZG9jdW1lbnROYW1lIjoiMjAyMS0wMy0yOSAtIFNoYWRvdyBBc3Nlc3NlbWVudCAtIEQwNy0xMi0yMS0wMDQwIiwiZmlsZVNpemUiOiIxNC45OSBNQiIsImZpbGVQYXRoIjoiU2l0ZSBQbGFuIEFwcGxpY2F0aW9uX0ltYWdlIFJlZmVyZW5jZV8yMDIxLTAzLTI5IC0gU2hhZG93IEFzc2Vzc2VtZW50IC0gRDA3LTEyLTIxLTAwNDAuUERGIn0seyJkb2NSZWZlcmVuY2VJZCI6Il9fQkRENlBWIiwiZG9jdW1lbnROYW1lIjoiMjAyMS0wMy0yOSAtIFNlcnZpY2luZyBhbmQgU3Rvcm13YXRlciBNYW5hZ2VtZW50IFJlcG9ydCAtIEQwNy0xMi0yMS0wMDQwIiwiZmlsZVNpemUiOiIxMy41NyBNQiIsImZpbGVQYXRoIjoiU2l0ZSBQbGFuIEFwcGxpY2F0aW9uX0ltYWdlIFJlZmVyZW5jZV8yMDIxLTAzLTI5IC0gU2VydmljaW5nIGFuZCBTdG9ybXdhdGVyIE1hbmFnZW1lbnQgUmVwb3J0IC0gRDA3LTEyLTIxLTAwNDAuUERGIn0seyJkb2NSZWZlcmVuY2VJZCI6Il9fQkRENktQIiwiZG9jdW1lbnROYW1lIjoiMjAyMS0wMy0yOSAtIFJvYWR3YXkgVHJhZmZpYyBOb2lzZSBBc3Nlc3NtZW50IC0gRDA3LTEyLTIxLTAwNDAiLCJmaWxlU2l6ZSI6IjEuODMgTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMS0wMy0yOSAtIFJvYWR3YXkgVHJhZmZpYyBOb2lzZSBBc3Nlc3NtZW50IC0gRDA3LTEyLTIxLTAwNDAuUERGIn0seyJkb2NSZWZlcmVuY2VJZCI6Il9fQkRENUdTIiwiZG9jdW1lbnROYW1lIjoiMjAyMS0wMy0yOSAtIFBsYW5uaW5nIFJhdGlvbmFsZSAtIEQwNy0xMi0yMS0wMDQwIiwiZmlsZVNpemUiOiI0LjE0IE1CIiwiZmlsZVBhdGgiOiJTaXRlIFBsYW4gQXBwbGljYXRpb25fSW1hZ2UgUmVmZXJlbmNlXzIwMjEtMDMtMjkgLSBQbGFubmluZyBSYXRpb25hbGUgLSBEMDctMTItMjEtMDA0MC5QREYifSx7ImRvY1JlZmVyZW5jZUlkIjoiX19CREQ1RU4iLCJkb2N1bWVudE5hbWUiOiIyMDIxLTAzLTI5IC0gUGxhbiBvZiBTdXJ2ZXkgLSBEMDctMTItMjEtMDA0MCIsImZpbGVTaXplIjoiMi44MSBNQiIsImZpbGVQYXRoIjoiU2l0ZSBQbGFuIEFwcGxpY2F0aW9uX0ltYWdlIFJlZmVyZW5jZV8yMDIxLTAzLTI5IC0gUGxhbiBvZiBTdXJ2ZXkgLSBEMDctMTItMjEtMDA0MC5QREYifSx7ImRvY1JlZmVyZW5jZUlkIjoiX19CREQ1OUMiLCJkb2N1bWVudE5hbWUiOiIyMDIxLTAzLTI5IC0gUGhhc2UgT25lIEVudmlyb25tZW50YWwgU2l0ZSBBc3Nlc3NtZW50IC0gRDA3LTEyLTIxLTAwNDAiLCJmaWxlU2l6ZSI6IjM0Ljc5IE1CIiwiZmlsZVBhdGgiOiJTaXRlIFBsYW4gQXBwbGljYXRpb25fSW1hZ2UgUmVmZXJlbmNlXzIwMjEtMDMtMjkgLSBQaGFzZSBPbmUgRW52aXJvbm1lbnRhbCBTaXRlIEFzc2Vzc21lbnQgLSBEMDctMTItMjEtMDA0MC5QREYifSx7ImRvY1JlZmVyZW5jZUlkIjoiX19CREQ1NkQiLCJkb2N1bWVudE5hbWUiOiIyMDIxLTAzLTI5IC0gUGVkZXN0cmlhbiBMZXZlbCBXaW5kIFN0dWR5IC0gRDA3LTEyLTIxLTAwNDAiLCJmaWxlU2l6ZSI6IjIuOTMgTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMS0wMy0yOSAtIFBlZGVzdHJpYW4gTGV2ZWwgV2luZCBTdHVkeSAtIEQwNy0xMi0yMS0wMDQwLlBERiJ9LHsiZG9jUmVmZXJlbmNlSWQiOiJfX0JERDU0ViIsImRvY3VtZW50TmFtZSI6IjIwMjEtMDMtMjkgLSBMYW5kc2NhcGUgUGxhbiAtIEQwNy0xMi0yMS0wMDQwIiwiZmlsZVNpemUiOiIwLjk5IE1CIiwiZmlsZVBhdGgiOiJTaXRlIFBsYW4gQXBwbGljYXRpb25fSW1hZ2UgUmVmZXJlbmNlXzIwMjEtMDMtMjkgLSBMYW5kc2NhcGUgUGxhbiAtIEQwNy0xMi0yMS0wMDQwLlBERiJ9LHsiZG9jUmVmZXJlbmNlSWQiOiJfX0JERDUyWCIsImRvY3VtZW50TmFtZSI6IjIwMjEtMDMtMjkgLSBFbmdpbmVlcmluZyBQbGFuIC0gRDA3LTEyLTIxLTAwNDAiLCJmaWxlU2l6ZSI6IjEuNjUgTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMS0wMy0yOSAtIEVuZ2luZWVyaW5nIFBsYW4gLSBEMDctMTItMjEtMDA0MC5QREYifSx7ImRvY1JlZmVyZW5jZUlkIjoiX19CREQ1MTYiLCJkb2N1bWVudE5hbWUiOiIyMDIxLTAzLTI5IC0gRWxldmF0aW9uIERyYXdpbmdzIC0gRDA3LTEyLTIxLTAwNDAiLCJmaWxlU2l6ZSI6IjAuODQgTUIiLCJmaWxlUGF0aCI6IlNpdGUgUGxhbiBBcHBsaWNhdGlvbl9JbWFnZSBSZWZlcmVuY2VfMjAyMS0wMy0yOSAtIEVsZXZhdGlvbiBEcmF3aW5ncyAtIEQwNy0xMi0yMS0wMDQwLlBERiJ9LHsiZG9jUmVmZXJlbmNlSWQiOiJfX0JERDVaRiIsImRvY3VtZW50TmFtZSI6IjIwMjEtMDMtMjkgLSBEZXNpZ24gQnJpZWYgLSBEMDctMTItMjEtMDA0MCIsImZpbGVTaXplIjoiMC44MCBNQiIsImZpbGVQYXRoIjoiU2l0ZSBQbGFuIEFwcGxpY2F0aW9uX0ltYWdlIFJlZmVyZW5jZV8yMDIxLTAzLTI5IC0gRGVzaWduIEJyaWVmIC0gRDA3LTEyLTIxLTAwNDAuUERGIn0seyJkb2NSZWZlcmVuY2VJZCI6Il9fQkRENVlVIiwiZG9jdW1lbnROYW1lIjoiMjAyMS0wMy0yOSAtIEN1bHR1cmFsIEhlcml0YWdlIEltcGFjdCBTdGF0ZW1lbnQgLSBEMDctMTItMjEtMDA0MCIsImZpbGVTaXplIjoiNi44NyBNQiIsImZpbGVQYXRoIjoiU2l0ZSBQbGFuIEFwcGxpY2F0aW9uX0ltYWdlIFJlZmVyZW5jZV8yMDIxLTAzLTI5IC0gQ3VsdHVyYWwgSGVyaXRhZ2UgSW1wYWN0IFN0YXRlbWVudCAtIEQwNy0xMi0yMS0wMDQwLlBERiJ9XSwib2JqZWN0U3RhdHVzIjp7Im9iamVjdFN0YXR1c1R5cGVJZCI6Il9fNE8zOFIyIiwib2JqZWN0Q3VycmVudFN0YXR1cyI6eyJlbiI6IlJlY2VpcHQgb2YgTGV0dGVyIG9mIFVuZGVydGFraW5nIGZyb20gT3duZXIgUGVuZGluZyIsImZyIjoiRW4gQXR0ZW50ZSBkZSBsYSBSw6ljZXB0aW9uIGRlIGxhIExldHRyZSBEJ2VuZ2FnZW1lbnQgZHUgUHJvcHJpw6l0YWlyZSJ9LCJvYmplY3RDdXJyZW50U3RhdHVzRGF0ZSI6NjM3ODQ2OTA4OTYwMDAwMDAwLCJvYmplY3RDdXJyZW50U3RhdHVzRGF0ZVlNRCI6IjIwMjItMDQtMDQifSwiZGV2QXBwV2FyZCI6eyJjb21tdW5pdHlJZCI6Il9fMzA1VDVGIiwid2FyZE51bWJlciI6eyJlbiI6IldhcmQgMTIiLCJmciI6IlF1YXJ0aWVyIDEyIn0sIndhcmROYW1lIjp7ImVuIjoiUklERUFVLVZBTklFUiIsImZyIjoiUklERUFVLVZBTklFUiJ9LCJjb3VuY2lsbG9yTGFzdE5hbWUiOiJGbGV1cnkiLCJjb3VuY2lsbG9yRmlyc3ROYW1lIjoiTWF0aGlldSIsIndhcmRDb3VuY2lsbG9yRW1haWwiOiJNYXRoaWV1LkZsZXVyeUBvdHRhd2EuY2EifSwiZW5kT2ZDaXJjdWxhdGlvbkRhdGUiOjAsImVuZE9mQ2lyY3VsYXRpb25EYXRlWU1EIjoiMDAwMS0wMS0wMSIsImNhbkNvbW1lbnQiOiJZIiwic2hvd0ZlZWRiYWNrTGluayI6Ik4iLCJwbGFubmVyRmlyc3ROYW1lIjoiQW5kcmV3IiwicGxhbm5lckxhc3ROYW1lIjoiTWNjcmVpZ2h0IiwicGxhbm5lclBob25lIjoiNjEzLTU4MC0yNDI0IHgyMjU2OCIsInBsYW5uZXJFbWFpbCI6ImFuZHJldy5tY2NyZWlnaHRAb3R0YXdhLmNhIiwic2VhcmNoYWJsZVRleHQiOiIyMTYgTVVSUkFZIFN0cmVldCBTaXRlIFBsYW4gQ29udHJvbCBSw6lnbGVtZW50YXRpb24gZHUgcGxhbiBkJ2ltcGxhbnRhdGlvbiBUaGUgQ2l0eSBvZiBPdHRhd2EgaGFzIHJlY2VpdmVkIFpvbmluZyBCeS1sYXcgQW1lbmRtZW50IGFuZCBTaXRlIFBsYW4gQ29udHJvbCBhcHBsaWNhdGlvbnMgdG8gcGVybWl0IHRoZSBkZXZlbG9wbWVudCBvZiBhbiA4LXN0b3JleSBtaXhlZC11c2UgYnVpbGRpbmcgd2l0aCA0OCBkd2VsbGluZyB1bml0cyBvbiBmbG9vcnMgdGhyZWUgdG8gZWlnaHQsIGFuZCBhIGNvbW11bml0eSBoZWFsdGggYW5kIHJlc291cmNlIGNlbnRyZSB0aGF0IGluY2x1ZGVzIGEgbG93LWJhcnJpZXIgZHJvcC1pbiBjZW50cmUgYW5kIGNvbW1lcmNpYWwga2l0Y2hlbiBhdCBncmFkZSBhbmQgb24gdGhlIHNlY29uZCBmbG9vci4gTGEgVmlsbGUgZCdPdHRhd2EgYSByZcOndSBkZXMgZGVtYW5kZXMgZGUgbW9kaWZpY2F0aW9uIGR1IFLDqGdsZW1lbnQgZGUgem9uYWdlIGV0IGRlIHLDqWdsZW1lbnRhdGlvbiBkdSBwbGFuIGQnaW1wbGFudGF0aW9uIHZpc2FudCDDoCBwZXJtZXR0cmUgbGEgY29uc3RydWN0aW9uIGQndW4gaW1tZXVibGUgcG9seXZhbGVudCBkZSBodWl0IMOpdGFnZXMgYWJyaXRhbnQgNDggbG9nZW1lbnRzIGR1IHRyb2lzacOobWUgYXUgaHVpdGnDqG1lIMOpdGFnZSwgYWluc2kgcXUndW4gY2VudHJlIGRlIHJlc3NvdXJjZXMgZXQgZGUgc2FudMOpIGNvbW11bmF1dGFpcmUgY29tcHJlbmFudCB1bmUgaGFsdGUtZ2FyZGVyaWUgc2FucyBvYnN0YWNsZSBldCB1bmUgY3Vpc2luZSBjb21tZXJjaWFsZSBhdSByZXotZGUtY2hhdXNzw6llIGV0IGF1IGRldXhpw6htZSDDqXRhZ2UuIEFjdGl2ZSBBY3RpZiBSZWNlaXB0IG9mIExldHRlciBvZiBVbmRlcnRha2luZyBmcm9tIE93bmVyIFBlbmRpbmcgRW4gQXR0ZW50ZSBkZSBsYSBSw6ljZXB0aW9uIGRlIGxhIExldHRyZSBEJ2VuZ2FnZW1lbnQgZHUgUHJvcHJpw6l0YWlyZSAgV2FyZCAxMiBRdWFydGllciAxMiBSSURFQVUtVkFOSUVSIFJJREVBVS1WQU5JRVIgTWF0aGlldSBGbGV1cnkgRDA3LTEyLTIxLTAwNDAiLCJzdHJlZXRBZHJlc3MiOiJNVVJSQVkiLCJzdHJlZXROdW1iZXIiOjIxNn0=
+  recorded_at: Sat, 09 Apr 2022 21:10:37 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2022-04-01+-+Signed+Delegated+Authority+Report+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:38 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:38 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2022-04-01+-+Approved+Tree+Conservation+Report+and+Landscape+Plan+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:38 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:38 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2022-04-01+-+Approved+Removals,+Site+Servicing,+Lot+Grading,+Drainage,+Sediment+&+Erosion+Control.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:38 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:38 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2022-04-01+-+Approved+Overall+Site+Plan+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:38 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:38 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2022-04-01+-+Approved+New+Site+Plan+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:38 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:38 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2022-04-01+-+Approved+Elevations+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:38 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:38 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-09-17+-+Stationary+Noise+Assessment+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:38 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:38 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-09-17+-+Site+Plan+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:38 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:38 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-09-17+-+Phase+Two+Environmental+Site+Assessment+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:38 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:38 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-09-17+-+Phase+One+Environmental+Site+Assessment+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:38 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:38 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-09-17+-+Geotechncial+Report+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:39 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:39 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-05-31+-+Tree+Conservation+and+Landscape+Report+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:39 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:39 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-05-31+-+Site+Plan+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:39 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:39 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-05-31+-+Servicing+and+Stormwater+Management+Report+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:39 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:39 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-05-31+-+Removals,+Site+Servicing,+Grading,+Erosion+Plan+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:39 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:39 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-05-31+-+Elevations+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:39 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:39 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-05-31+-+Cultural+Heritage+Impact+Statement+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:39 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:39 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-04-07+-+Application+Summary+and+Location+Map+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:39 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:39 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-04-01+-+UDRP+Design+Brief+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:39 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:39 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-31+-+Geotechncial+Report+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:39 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:39 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Transportation+Impact+Memo+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:39 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:40 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Traffic+Noise+Assessment+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:40 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:40 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Site+Plan+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:40 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:40 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Shadow+Assessement+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:40 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:40 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Servicing+and+Stormwater+Management+Report+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:40 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:40 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Roadway+Traffic+Noise+Assessment+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:40 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:40 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Planning+Rationale+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:40 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:40 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Plan+of+Survey+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:40 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:40 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Phase+One+Environmental+Site+Assessment+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:40 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:40 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Pedestrian+Level+Wind+Study+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:40 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:40 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Landscape+Plan+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:40 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:40 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Engineering+Plan+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:40 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:40 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Elevation+Drawings+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:40 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:41 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Design+Brief+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:40 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:41 GMT
+- request:
+    method: head
+    uri: http://webcast.ottawa.ca/plan/All_Image%20Referencing_Site+Plan+Application_Image+Reference_2021-03-29+-+Cultural+Heritage+Impact+Statement+-+D07-12-21-0040.PDF
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '1245'
+      Content-Type:
+      - text/html
+      Server:
+      - Microsoft-IIS/8.5
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Sat, 09 Apr 2022 21:10:41 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sat, 09 Apr 2022 21:10:41 GMT
+recorded_with: VCR 6.1.0

--- a/test/fixtures/announcements.yml
+++ b/test/fixtures/announcements.yml
@@ -1,5 +1,4 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
 one:
   message: This is an announcement
   reference_id: <%= DevApp::Entry.find_by(app_number: "D07-05-16-0003").id %> 

--- a/test/models/dev_app/scanner_test.rb
+++ b/test/models/dev_app/scanner_test.rb
@@ -64,6 +64,14 @@ class DevApp::ScannerTest < ActiveSupport::TestCase
     end
   end
 
+  test "documents have HTTP_HEAD state results cached in the db" do
+    VCR.use_cassette("#{class_name}_#{method_name}") do
+      entry = DevApp::Scanner.scan_application("D07-12-21-0040")
+      assert_equal 35, entry.documents.map{|d| d.state}.count
+      assert_equal ["404"], entry.documents.map{|d| d.state}.uniq
+    end
+  end
+
   test "devapp status changes are announced" do
     VCR.use_cassette("#{class_name}_#{method_name}") do
       entry = DevApp::Scanner.scan_application(APP_NUMBER)


### PR DESCRIPTION
Way too many of the files published alongside Development Applications are not actually available.

This has been a theme for awhile. Overtime I learned that the files just "sometimes don't upload" when staff do whatever they do on the city's IT systems. I would email, let them know, they'd email someone else, the problem would get fixed and life moves on.

I think it's gotten worse though. It seems that every file I've manually checked is missing. Are they *all* missing? Let's find out!

OttWatch already scans all available devapps every 4 hours, so I'm adding new things to that existing process:

- a new column, per file, to record it's "state"
- a "HTTP HEAD" operation on the URL of the file. If the file is there it'll be a `200` response. If it's missing, `404`.

When this is deployed the `state` column will start out as `nil`, meaning no value. Then after I run the job manually or let the regular 4-hr schedule get around to it, the scanner will scan and values will get filled in.

Then I'll run a quick query to see what percentage of files are missing. Hopefully it's not all of them, but at a glance it feels like there will be an unacceptable number.