### PR TITLE
oc transpo next stop

### DIFF
--- a/app/controllers/transpo_controller.rb
+++ b/app/controllers/transpo_controller.rb
@@ -1,0 +1,57 @@
+class TranspoController < ApplicationController
+  def self.get_next_trips_for_stop_all_routes(stop_no)
+    app_id = ENV["OCTRANSPO_APP_ID"]
+    api_key = ENV["OCTRANSPO_APP_KEY"]
+
+    url = "https://api.octranspo1.com/v2.0/GetNextTripsForStopAllRoutes?appID=#{app_id}&apiKey=#{api_key}&stopNo=#{stop_no}&format=JSON"
+    data = Net::HTTP.get(URI(url))
+    Rails.logger.info(data)
+    data
+  end
+
+  def self.stop_trips(stop_no)
+    data = get_next_trips_for_stop_all_routes(stop_no)
+    data = JSON.parse(data)["GetRouteSummaryForStopResult"]
+
+    routes = data["Routes"]["Route"]
+    routes = [routes] if routes.is_a?(Hash)
+    routes = routes.map do |r|
+      trips = if r["Trips"].is_a?(Array)
+        r["Trips"]
+      elsif r["Trips"].is_a?(Hash)
+        if r["Trips"]["Trip"]
+          r["Trips"]["Trip"]
+        else
+          [r["Trips"]]
+        end
+      end
+
+      trips = trips.map do |t|
+        age = (t["AdjustmentAge"].to_f * 60).round
+        {
+          # lat: t["Latitude"],
+          # lon: t["Longitude"],
+          # speed: t["GPSSpeed"],
+          dest: t["TripDestination"],
+          in: t["AdjustedScheduleTime"],
+          age: age,
+          per: (age < 0 ? :sched : :gps)
+        }
+      end
+      {
+        no: r["RouteNo"],
+        heading: r["RouteHeading"],
+        trips: trips
+      }
+    end
+    {
+      no: data["StopNo"],
+      desc: data["StopDescription"],
+      routes: routes
+    }
+  end
+
+  def show_stop
+    @stop_data = self.class.stop_trips(params[:stop_no])
+  end
+end

--- a/app/views/transpo/show_stop.html.erb
+++ b/app/views/transpo/show_stop.html.erb
@@ -1,0 +1,29 @@
+<h1><%= @stop_data[:no] %> <%= @stop_data[:desc] %></h1>
+<%
+@stop_data[:routes].each do |r|
+  %>
+  <h2>
+    <%= r[:no] %>
+    <%= r[:heading] %>
+  </h2>
+  <ul>
+    <%
+    r[:trips].each do |t|
+      %>
+      <li>
+      <%= t[:in] %>m, per <%= t[:per] %>
+      <%
+        if t[:per] == :gps
+          %>
+          (<%= t[:age] %>)
+          <%
+        end
+      %>
+      </li>
+      <%
+    end
+    %>
+  </ul>
+  <%
+end
+%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'transpo/show_stop'
   get 'service_requests/index'
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
 

--- a/test/controllers/transpo_controller_test.rb
+++ b/test/controllers/transpo_controller_test.rb
@@ -1,0 +1,588 @@
+require "test_helper"
+
+class TranspoControllerTest < ActionDispatch::IntegrationTest
+  test "4940" do
+    TranspoController.expects(:get_next_trips_for_stop_all_routes).with("4940").returns(ROUTE_SUMMARY_4940)
+    TranspoController.stop_trips("4940")
+  end
+
+  test "3011" do
+    TranspoController.expects(:get_next_trips_for_stop_all_routes).with("3011").returns(ROUTE_SUMMARY_3011)
+    TranspoController.stop_trips("3011")
+  end
+
+  ROUTE_SUMMARY_3011 = <<-JSON
+  {
+    "GetRouteSummaryForStopResult": {
+      "StopNo": "3011",
+      "Error": "",
+      "StopDescription": "TUNNEY'S PASTURE",
+      "Routes": {
+        "Route": [
+          {
+            "RouteNo": "1",
+            "RouteHeading": "Blair",
+            "DirectionID": 0,
+            "Direction": "",
+            "Trips": [
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Blair",
+                "TripStartTime": "",
+                "AdjustedScheduleTime": "0",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Blair",
+                "TripStartTime": "",
+                "AdjustedScheduleTime": "9",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Blair",
+                "TripStartTime": "",
+                "AdjustedScheduleTime": "19",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              }
+            ]
+          },
+          {
+            "RouteNo": "11",
+            "RouteHeading": "Parliament",
+            "DirectionID": 0,
+            "Direction": "",
+            "Trips": [
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Laurier",
+                "TripStartTime": "23:08",
+                "AdjustedScheduleTime": "27",
+                "AdjustmentAge": "0.50",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Laurier",
+                "TripStartTime": "23:38",
+                "AdjustedScheduleTime": "57",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Laurier",
+                "TripStartTime": "00:08",
+                "AdjustedScheduleTime": "87",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              }
+            ]
+          },
+          {
+            "RouteNo": "11",
+            "RouteHeading": "Bayshore",
+            "DirectionID": 1,
+            "Direction": "",
+            "Trips": [
+              {
+                "Longitude": "-75.6961489738302",
+                "Latitude": "45.42257057352269",
+                "GPSSpeed": "0",
+                "TripDestination": "Lincoln Fields",
+                "TripStartTime": "22:57",
+                "AdjustedScheduleTime": "19",
+                "AdjustmentAge": "0.50",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Lincoln Fields",
+                "TripStartTime": "23:27",
+                "AdjustedScheduleTime": "50",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Lincoln Fields",
+                "TripStartTime": "23:57",
+                "AdjustedScheduleTime": "80",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              }
+            ]
+          },
+          {
+            "RouteNo": "14",
+            "RouteHeading": "St-Laurent",
+            "DirectionID": 0,
+            "Direction": "",
+            "Trips": [
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "St-Laurent",
+                "TripStartTime": "23:15",
+                "AdjustedScheduleTime": "14",
+                "AdjustmentAge": "0.58",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "St-Laurent",
+                "TripStartTime": "23:45",
+                "AdjustedScheduleTime": "44",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "St-Laurent",
+                "TripStartTime": "00:15",
+                "AdjustedScheduleTime": "74",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              }
+            ]
+          },
+          {
+            "RouteNo": "51",
+            "RouteHeading": "Britannia",
+            "DirectionID": 1,
+            "Direction": "",
+            "Trips": [
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Lincoln Fields",
+                "TripStartTime": "23:17",
+                "AdjustedScheduleTime": "16",
+                "AdjustmentAge": "0.53",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Britannia",
+                "TripStartTime": "23:45",
+                "AdjustedScheduleTime": "44",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              }
+            ]
+          },
+          {
+            "RouteNo": "53",
+            "RouteHeading": "Carlington",
+            "DirectionID": 1,
+            "Direction": "",
+            "Trips": [
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Carlington",
+                "TripStartTime": "23:27",
+                "AdjustedScheduleTime": "26",
+                "AdjustmentAge": "0.50",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Carlington",
+                "TripStartTime": "23:57",
+                "AdjustedScheduleTime": "56",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Carlington",
+                "TripStartTime": "00:27",
+                "AdjustedScheduleTime": "86",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              }
+            ]
+          },
+          {
+            "RouteNo": "56",
+            "RouteHeading": "King Edward & Civic",
+            "DirectionID": 0,
+            "Direction": "",
+            "Trips": [
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Civic",
+                "TripStartTime": "23:30",
+                "AdjustedScheduleTime": "29",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Civic",
+                "TripStartTime": "00:10",
+                "AdjustedScheduleTime": "69",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              }
+            ]
+          },
+          {
+            "RouteNo": "57",
+            "RouteHeading": "Crystal Bay",
+            "DirectionID": 1,
+            "Direction": "",
+            "Trips": [
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Bayshore",
+                "TripStartTime": "23:30",
+                "AdjustedScheduleTime": "29",
+                "AdjustmentAge": "0.50",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Bayshore",
+                "TripStartTime": "00:00",
+                "AdjustedScheduleTime": "59",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Bayshore",
+                "TripStartTime": "00:30",
+                "AdjustedScheduleTime": "89",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              }
+            ]
+          },
+          {
+            "RouteNo": "61",
+            "RouteHeading": "Stittsville",
+            "DirectionID": 1,
+            "Direction": "",
+            "Trips": [
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Stittsville",
+                "TripStartTime": "23:25",
+                "AdjustedScheduleTime": "24",
+                "AdjustmentAge": "0.58",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Terry Fox",
+                "TripStartTime": "23:55",
+                "AdjustedScheduleTime": "54",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Terry Fox",
+                "TripStartTime": "00:24",
+                "AdjustedScheduleTime": "83",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              }
+            ]
+          },
+          {
+            "RouteNo": "63",
+            "RouteHeading": "Briarbrook via Innovation",
+            "DirectionID": 0,
+            "Direction": "",
+            "Trips": [
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Innovation",
+                "TripStartTime": "23:30",
+                "AdjustedScheduleTime": "29",
+                "AdjustmentAge": "0.50",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Innovation",
+                "TripStartTime": "00:00",
+                "AdjustedScheduleTime": "59",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              }
+            ]
+          },
+          {
+            "RouteNo": "75",
+            "RouteHeading": "Barrhaven Centre",
+            "DirectionID": 1,
+            "Direction": "",
+            "Trips": [
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Barrhaven Centre",
+                "TripStartTime": "23:17",
+                "AdjustedScheduleTime": "16",
+                "AdjustmentAge": "0.58",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Barrhaven Centre",
+                "TripStartTime": "23:32",
+                "AdjustedScheduleTime": "31",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Barrhaven Centre",
+                "TripStartTime": "23:55",
+                "AdjustedScheduleTime": "54",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              }
+            ]
+          },
+          {
+            "RouteNo": "80",
+            "RouteHeading": "Barrhaven Centre",
+            "DirectionID": 0,
+            "Direction": "",
+            "Trips": [
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Barrhaven Centre",
+                "TripStartTime": "23:30",
+                "AdjustedScheduleTime": "29",
+                "AdjustmentAge": "0.42",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Barrhaven Centre",
+                "TripStartTime": "00:00",
+                "AdjustedScheduleTime": "59",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              }
+            ]
+          },
+          {
+            "RouteNo": "86",
+            "RouteHeading": "Baseline",
+            "DirectionID": 1,
+            "Direction": "",
+            "Trips": {
+              "Longitude": "",
+              "Latitude": "",
+              "GPSSpeed": "",
+              "TripDestination": "Baseline",
+              "TripStartTime": "23:48",
+              "AdjustedScheduleTime": "47",
+              "AdjustmentAge": "-1",
+              "LastTripOfSchedule": false,
+              "BusType": ""
+            }
+          },
+          {
+            "RouteNo": "89",
+            "RouteHeading": "Colonnade",
+            "DirectionID": 1,
+            "Direction": "",
+            "Trips": [
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Colonnade",
+                "TripStartTime": "23:03",
+                "AdjustedScheduleTime": "2",
+                "AdjustmentAge": "0.47",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Colonnade",
+                "TripStartTime": "23:33",
+                "AdjustedScheduleTime": "32",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              },
+              {
+                "Longitude": "",
+                "Latitude": "",
+                "GPSSpeed": "",
+                "TripDestination": "Colonnade",
+                "TripStartTime": "00:03",
+                "AdjustedScheduleTime": "62",
+                "AdjustmentAge": "-1",
+                "LastTripOfSchedule": false,
+                "BusType": ""
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+  JSON
+
+  ROUTE_SUMMARY_4940 = <<-JSON
+    {
+      "GetRouteSummaryForStopResult": {
+        "StopNo": "4940",
+        "Error": "",
+        "StopDescription": "RICHMOND / WESTMINSTER",
+        "Routes": {
+          "Route": {
+            "RouteNo": "11",
+            "RouteHeading": "Parliament",
+            "DirectionID": 0,
+            "Direction": "",
+            "Trips": {
+              "Trip": [
+                {
+                  "Longitude": "-75.7856342212574",
+                  "Latitude": "45.36580668268977",
+                  "GPSSpeed": "18",
+                  "TripDestination": "Laurier",
+                  "TripStartTime": "22:38",
+                  "AdjustedScheduleTime": "5",
+                  "AdjustmentAge": "0.62",
+                  "LastTripOfSchedule": false,
+                  "BusType": ""
+                },
+                {
+                  "Longitude": "",
+                  "Latitude": "",
+                  "GPSSpeed": "",
+                  "TripDestination": "Laurier",
+                  "TripStartTime": "23:08",
+                  "AdjustedScheduleTime": "34",
+                  "AdjustmentAge": "-1",
+                  "LastTripOfSchedule": false,
+                  "BusType": ""
+                },
+                {
+                  "Longitude": "",
+                  "Latitude": "",
+                  "GPSSpeed": "",
+                  "TripDestination": "Laurier",
+                  "TripStartTime": "23:38",
+                  "AdjustedScheduleTime": "64",
+                  "AdjustmentAge": "-1",
+                  "LastTripOfSchedule": false,
+                  "BusType": ""
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  JSON
+end


### PR DESCRIPTION
MVP (minimal viable product) for an OC Transpo "next bus" page.

This is essentially a very thin wrapper around the `GetNextTripsForStopAllRoutes` API endpoint. Basically dump the stop number provided as a GET param to the API, then do some light parsing (!!!) on the unstable JSON that is returned, then dump simple HTML "next 3 stop" info.

Nothing fancy, but this replicates an earlier version of this app that I did ages ago. In future quick commits I'll add: 

- input box to query a stop, instead of hand-editing the URL
- filter by specific busses
- make bus entries a link, to make filtering more accessible to user

I use this by bookmarking the pages on my phone homescreen. No fuss, no muss, super UX 👍 

<img width="1270" alt="image" src="https://github.com/kevinodotnet/ottwatch/assets/2074233/ea3cfd68-59cb-4d47-8c50-6bdff6347b49">
