### PR TITLE
browse all announcements with filters

### DIFF
--- a/app/controllers/announcement_controller.rb
+++ b/app/controllers/announcement_controller.rb
@@ -1,0 +1,10 @@
+class AnnouncementController < ApplicationController
+  def index
+    relation = Announcement.all
+    relation = relation.where(reference_type: params[:reference_type]) if params[:reference_type]
+    relation = relation.where('id < ?', params[:before_id]) if params[:before_id]
+    relation = relation.limit(params[:limit] || 50)
+    @announcements = relation.order(id: :desc)
+
+  end
+end

--- a/app/helpers/announcement_helper.rb
+++ b/app/helpers/announcement_helper.rb
@@ -1,0 +1,2 @@
+module AnnouncementHelper
+end

--- a/app/views/announcement/index.html.erb
+++ b/app/views/announcement/index.html.erb
@@ -1,0 +1,48 @@
+<div class="row">
+  <div class="col-8">
+    <h4>
+    Announcements
+    <small>
+    <%= link_to("all", announcement_index_path) %>
+    <%= link_to("devapps", announcement_index_path(reference_type: "DevApp::Entry")) %>
+    <%= link_to("meetings", announcement_index_path(reference_type: "Meeting")) %>
+    <%= link_to("consultations", announcement_index_path(reference_type: "Consultation")) %>
+    <%= link_to("lobbying", announcement_index_path(reference_type: "LobbyingUndertaking")) %>
+    </small>
+    </h4>
+  </div>
+
+  <div class="col-4 text-end">
+    Next:
+    <% [10, 25, 50, 100, 250].each do |limit| %>
+      <%= link_to(
+        "#{limit}", 
+        announcement_index_path(
+          before_id: @announcements.last&.id,
+          reference_type: params[:reference_type],
+          limit: limit
+        )
+      ) %>
+    <% end %>
+  </div>
+</div>
+
+<div class="owrows">
+<% @announcements.each do |a| %>
+  <div class="row">
+    <div class="col-10">
+      <%
+      message = a.message
+      message = [a.message, a.reference_context].join(" ") if a.reference_type == "LobbyingUndertaking"
+      %>
+      <%= link_to(message, a.reference_link) %>
+    </div>
+    <div class="col-2" style="text-align: right;">
+      <%= a.created_at.in_time_zone("America/New_York").strftime("%Y-%m-%d %H:%M") %>
+    </div>
+  </div>
+<% end %>
+</div>
+
+
+

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -22,21 +22,7 @@
     </div>
   <% end %>
 </div>
-<div style="margin-top: 10px; margin-bottom: 10px;">
-  <h2>Recent announcements</h2>
-</div>
-<div class="owrows">
-  <% @announcements.each do |a| %>
-    <div class="row">
-      <div class="col-sm-3">
-        <%= link_to(a.reference_context || a.reference.class, a.reference_link) %>
-      </div>
-      <div class="col-md-7">
-        <%= a.message %>
-      </div>
-      <div class="col-md-2" style="text-align: right;">
-        <%= a.created_at.in_time_zone("America/New_York").strftime("%Y-%m-%d") %>
-      </div>
-    </div>
-  <% end %>
-</div>
+
+<hr/>
+
+<div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,6 +60,9 @@
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
             <li class="nav-item">
+              <%= link_to "Announcements", announcement_index_path, class: "nav-link" %>
+            </li>
+            <li class="nav-item">
               <a class="nav-link" href="/devapp/index">DevApps</a>
             </li>
             <li class="nav-item">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'announcement/index'
   get 'transpo/show_stop'
   get 'service_requests/index'
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }

--- a/test/controllers/announcement_controller_test.rb
+++ b/test/controllers/announcement_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class AnnouncementControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get announcement_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
General browsing for all recent announcements with: 

- filter by type
- "next" page that retains filters
- or view them all

This allows the main page to be slimmed down, and also lets users to back in history to the very beginning

<img width="1351" alt="image" src="https://github.com/kevinodotnet/ottwatch/assets/2074233/248df3a1-6e4a-41e3-a26d-8515b6624962">
