### PR TITLE
highlight new announcements

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -40,3 +40,7 @@ a {
 a:hover {
   text-decoration: underline !important;
 }
+
+.new_announcement_badge {
+  color: #7aa126;
+}

--- a/app/controllers/announcement_controller.rb
+++ b/app/controllers/announcement_controller.rb
@@ -5,6 +5,5 @@ class AnnouncementController < ApplicationController
     relation = relation.where('id < ?', params[:before_id]) if params[:before_id]
     relation = relation.limit(params[:limit] || 50).includes(:reference)
     @announcements = relation.order(id: :desc)
-
   end
 end

--- a/app/views/announcement/index.html.erb
+++ b/app/views/announcement/index.html.erb
@@ -1,3 +1,10 @@
+<%
+
+last_key = params["reference_type"] || "all"
+last_id = session["annoucements_index_#{last_key}"] || 0
+session["annoucements_index_#{last_key}"] = @announcements.first.id
+
+%>
 <div class="row">
   <div class="col-8">
     <h4>
@@ -14,7 +21,7 @@
 
   <div class="col-4 text-end">
     Next:
-    <% [10, 25, 50, 100, 250].each do |limit| %>
+    <% [25, 50, 100].each do |limit| %>
       <%= link_to(
         "#{limit}", 
         announcement_index_path(
@@ -28,21 +35,18 @@
 </div>
 
 <div class="owrows">
-<% @announcements.each do |a| %>
+<% @announcements.each do |a|
+  message = a.message
+  message = [a.message, a.reference_context].join(" ") if a.reference_type == "LobbyingUndertaking"
+  %>
   <div class="row">
     <div class="col-9">
-      <%
-      message = a.message
-      message = [a.message, a.reference_context].join(" ") if a.reference_type == "LobbyingUndertaking"
-      %>
       <%= link_to(message, a.reference_link) %>
     </div>
     <div class="col-3 text-nowrap" style="text-align: right">
+      <%= raw("<span class=\"new_announcement_badge\">(new)</span>") if a.id > last_id %>
       <%= a.created_at.in_time_zone("America/New_York").strftime("%Y-%m-%d") %>
     </div>
   </div>
 <% end %>
 </div>
-
-
-


### PR DESCRIPTION
Progress on https://github.com/kevinodotnet/ottwatch/issues/105

Session (cookies currenly) values are used to highlight announcements that are new, relative to the user's previous page load. Works for the "type" filters too.

Should help a user more quickly find only what they are interested in knowing: "what's new since the last time I checked in?" 

![image](https://github.com/kevinodotnet/ottwatch/assets/2074233/ed768e29-528a-48de-ba51-249d5cee4355)
