### PR TITLE
separate announcements by date

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -44,3 +44,26 @@ a:hover {
 .new_announcement_badge {
   color: #7aa126;
 }
+
+.owrows {
+  /* border-top: solid 1px #c0c0c0;
+  border-bottom: solid 1px #c0c0c0;
+  */
+}
+.owrows .row:nth-child(odd) {
+  background: #f0f0f0;
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+.owrows .row:nth-child(even) {
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+.ow_footer {
+  margin-top: 25px; 
+  padding: 10px; 
+  background: #f0f0f0;
+  /* border: solid 1px #c0c0c0; */
+  font-size: 90%;
+  font-style: italic;
+}

--- a/app/views/announcement/index.html.erb
+++ b/app/views/announcement/index.html.erb
@@ -34,18 +34,25 @@ session["annoucements_index_#{last_key}"] = @announcements.first.id
   </div>
 </div>
 
-<div class="owrows">
-<% @announcements.each do |a|
+<% 
+prev_date = nil
+@announcements.each do |a| 
+  is_new_date = a.created_at.to_date != prev_date
+  if is_new_date
+    %>
+    <h5 style="padding-top: 10px;"><%= a.created_at.in_time_zone("America/New_York").strftime("%Y-%m-%d") %></h5>
+    <%
+  end
+  prev_date = a.created_at.to_date
   message = a.message
   message = [a.message, a.reference_context].join(" ") if a.reference_type == "LobbyingUndertaking"
   %>
-  <div class="row">
+  <div class="row" style="margin-top: 2px;">
     <div class="col-9">
       <%= link_to(message, a.reference_link) %>
     </div>
     <div class="col-3 text-nowrap" style="text-align: right">
       <%= raw("<span class=\"new_announcement_badge\">(new)</span>") if a.id > last_id %>
-      <%= a.created_at.in_time_zone("America/New_York").strftime("%Y-%m-%d") %>
     </div>
   </div>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,27 +16,6 @@
     <%= auto_discovery_link_tag :rss, "https://ottwatch.ca/home/index.rss" %>
 
     <style>
-.owrows {
-  border-top: solid 1px #c0c0c0;
-  border-bottom: solid 1px #c0c0c0;
-}
-.owrows .row:nth-child(odd) {
-  background: #f0f0f0;
-  padding-top: 5px;
-  padding-bottom: 5px;
-}
-.owrows .row:nth-child(even) {
-  padding-top: 5px;
-  padding-bottom: 5px;
-}
-.ow_footer {
-  margin-top: 25px; 
-  padding: 10px; 
-  background: #f0f0f0;
-  border: solid 1px #c0c0c0;
-  font-size: 90%;
-  font-style: italic;
-}
     </style>
 
     <% if Rails.env.production? %>


### PR DESCRIPTION
Progress on https://github.com/kevinodotnet/ottwatch/issues/105

- separate each day's announcements with a date heading
- remove the date from each row; don't repeat yourself and be tautological

<img width="1212" alt="image" src="https://github.com/kevinodotnet/ottwatch/assets/2074233/08f43c0c-6014-4985-84a5-d2cdda848505">
