### PR TITLE
clone zonings monthly with snapshot date

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -25,7 +25,7 @@ parcel_scanner:
    class: "ParcelScanner"
 
 zoning_scanner:
-   cron: "0 4 * * *"
+   cron: "0 2 * * *"
    class: "ZoningScanner"
 
 consultation_scanner:

--- a/db/migrate/20240201195110_add_snapshot_date_to_zonings.rb
+++ b/db/migrate/20240201195110_add_snapshot_date_to_zonings.rb
@@ -1,0 +1,7 @@
+class AddSnapshotDateToZonings < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :zonings, name: "index_zonings_on_objectid"
+    add_column :zonings, :snapshot_date, :date
+    add_index :zonings, [:snapshot_date, :objectid], :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_28_030031) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_01_195110) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -329,7 +329,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_28_030031) do
     t.text "geometry_json", size: :long
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["objectid"], name: "index_zonings_on_objectid", unique: true
+    t.date "snapshot_date"
+    t.index ["snapshot_date", "objectid"], name: "index_zonings_on_snapshot_date_and_objectid", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/v1_schema.rb
+++ b/db/v1_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_28_030031) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_01_195110) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -329,7 +329,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_28_030031) do
     t.text "geometry_json", size: :long
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["objectid"], name: "index_zonings_on_objectid", unique: true
+    t.date "snapshot_date"
+    t.index ["snapshot_date", "objectid"], name: "index_zonings_on_snapshot_date_and_objectid", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/models/zoning_scanner_test.rb
+++ b/test/models/zoning_scanner_test.rb
@@ -11,4 +11,13 @@ class ZoningScannerTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "#perform uses first day of month as snapshot_date and pulls a full clone each month" do
+    VCR.use_cassette("#{class_name}_#{method_name}") do
+      travel_to(Time.zone.local(2023, 12, 15, 01, 02, 03)) do
+        ZoningScanner.new.perform
+      end
+      assert_equal "2023-12-01".to_date, Zoning.first.snapshot_date
+    end
+  end
 end


### PR DESCRIPTION
Following the pattern established for Parcel scraping, capture a full clone of the zoning GIS layer each month