### PR TITLE
OC Transpo show routes UX improvements

### DIFF
--- a/app/views/transpo/show_stop.html.erb
+++ b/app/views/transpo/show_stop.html.erb
@@ -44,30 +44,33 @@
 
 <%= form_with(url: transpo_show_stop_path, method: :get) do |form| %>
   <div class="row">
-    <div class="col-6 col-sm-3">
-      <%= form.label(:stop_no, "Stop Number:") %> 
+    <div class="col-3">
+      <%= form.label(:stop_no, "Stop:") %>
     </div>
-    <div class="col-6">
-      <%= form.text_field(:stop_no, value: params[:stop_no], required: true) %>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-6 col-sm-3">
-      <%= form.label(:stop_routes, "Routes:") %> 
-    </div>
-    <div class="col-6">
-      <%= form.text_field(:stop_routes, value: params[:stop_routes]) %>
+    <div class="col-9">
+      <%= form.text_field(:stop_no, value: params[:stop_no], required: true, class: "form-control") %>
     </div>
   </div>
   <div class="row">
-    <div class="col-6 col-sm-3">
+    <div class="col-3">
+      <%= form.label(:stop_routes, "Route(s):") %>
     </div>
-    <div class="col-6">
-      <%= form.submit("Search") %>
+    <div class="col-9">
+      <%= form.text_field(:stop_routes, value: params[:stop_routes], class: "form-control") %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-3">
+    </div>
+    <div class="col-9">
+      <%= form.submit("Search", class: "btn btn-primary") %>
     </div>
   </div>
 
-<p style="padding-top: 10px;">
+
+
+<h5 style="padding-top: 20px;">Instructions</h5>
+<p>
 Enter a stop number ("4940") and optionally one or more route numbers ("11 59") separated
 by spaces to get the next available trips in all directions. If you leave the route number(s)
 empty, all routes servicing that stop will be shown.

--- a/app/views/transpo/show_stop.html.erb
+++ b/app/views/transpo/show_stop.html.erb
@@ -8,9 +8,7 @@
 <% if @stop_data.is_a?(Hash) %>
   <% content_for :html_title, "#{@stop_data[:no]}: #{@stop_data[:desc]}" %>
 
-  <h3><%= @stop_data[:no] %> <%= @stop_data[:desc] %>
-  <small>(<%= link_to "all", transpo_show_stop_path(stop_no: params[:stop_no]) %>)</small>
-  </h3>
+  <h3><%= link_to("#{@stop_data[:no]} #{@stop_data[:desc]}", transpo_show_stop_path(stop_no: params[:stop_no])) %></h3>
   <%
   @stop_data[:routes].each do |r|
     %>
@@ -27,7 +25,7 @@
         <%
           if t[:per] == :gps
             %>
-            (<%= t[:age] %>)
+            (as of <%= t[:age] %>s ago)
             <%
           end
         %>


### PR DESCRIPTION
Closes https://github.com/kevinodotnet/ottwatch/issues/124

- results area: cleaned up text and moved the "all" search link to be part of the stop title itself
- search area: added Bootstrap form control classes

# After

<img width="310" alt="image" src="https://github.com/kevinodotnet/ottwatch/assets/2074233/db400f12-48bf-469d-8e7c-c54810217037">

# Before

<img width="281" alt="image" src="https://github.com/kevinodotnet/ottwatch/assets/2074233/39f59cc5-ca0d-4bbb-9ca7-41d594c53443">
