### PR TITLE
Add a map view for development applications

### DIFF
--- a/app/controllers/devapp_controller.rb
+++ b/app/controllers/devapp_controller.rb
@@ -13,6 +13,8 @@ class DevappController < ApplicationController
   def show
     @entry = DevApp::Entry.where(app_number: params[:app_number]).includes(:statuses, :addresses, :documents).first
     return render plain: "404 Not Found", status: 404 unless @entry
+
+    @coordinates = @entry.addresses.first&.coordinates
   end
 
   def map
@@ -27,6 +29,9 @@ class DevappController < ApplicationController
   def map_data
     geojson = {
       type: "FeatureCollection",
+      # TODO: group the data by unique address and update the popup to show the different apps at the address.
+      # Unsure at the moment whether the map is move valuable showing distinct applications (pin to first address) or
+      # distinct list of addresses and possible displaying the same app multiple times.
       features: DevApp::Entry.includes(:addresses, :statuses).filter_map do |app|
         next unless (coordinates = app.addresses.first&.coordinates)
 

--- a/app/controllers/devapp_controller.rb
+++ b/app/controllers/devapp_controller.rb
@@ -45,7 +45,7 @@ class DevappController < ApplicationController
             id: app.id,
             app_number: app.app_number,
             app_type: app.app_type,
-            status: app.statuses.last&.status,
+            status: app.current_status.status,
             description: app.desc.truncate(140, separator: /\s/),
             url: url_for(controller: 'devapp', action: 'show', app_number: app.app_number)
           }

--- a/app/controllers/devapp_controller.rb
+++ b/app/controllers/devapp_controller.rb
@@ -14,4 +14,40 @@ class DevappController < ApplicationController
     @entry = DevApp::Entry.where(app_number: params[:app_number]).includes(:statuses, :addresses, :documents).first
     return render plain: "404 Not Found", status: 404 unless @entry
   end
+
+  def map
+    ottawa_city_hall = Coordinates.new(45.420906, -75.689374)
+    @initial_lat = ottawa_city_hall.lat
+    @initial_lon = ottawa_city_hall.lon
+
+    @statuses = DevApp::Status.distinct.pluck(:status).sort
+    @app_types = DevApp::Entry.distinct.pluck(:app_type).sort
+  end
+
+  def map_data
+    geojson = {
+      type: "FeatureCollection",
+      features: DevApp::Entry.includes(:addresses, :statuses).filter_map do |app|
+        next unless (coordinates = app.addresses.first&.coordinates)
+
+        {
+          type: "Feature",
+          geometry: {
+            type: "Point",
+            coordinates: [coordinates.lon, coordinates.lat],
+          },
+          properties: {
+            id: app.id,
+            app_number: app.app_number,
+            app_type: app.app_type,
+            status: app.statuses.last&.status,
+            description: app.desc.truncate(140, separator: /\s/),
+            url: url_for(controller: 'devapp', action: 'show', app_number: app.app_number)
+          }
+        }
+      end
+    }
+
+    render json: geojson
+  end
 end

--- a/app/javascript/controllers/devapp_show_controller.js
+++ b/app/javascript/controllers/devapp_show_controller.js
@@ -1,0 +1,50 @@
+import { Controller } from "@hotwired/stimulus"
+import maplibregl from 'maplibre-gl'
+
+export default class extends Controller {
+  static targets = ["map"]
+
+  connect() {
+    if (this.hasMapTarget) {
+      this.initMap()
+    }
+  }
+
+  initMap() {
+    const lat = this.mapTarget.dataset.lat
+    const lon = this.mapTarget.dataset.lon
+
+    if (!lat || !lon) {
+      console.error("Latitude or longitude not provided")
+      return
+    }
+
+    this.map = new maplibregl.Map({
+      container: this.mapTarget,
+      style: {
+        version: 8,
+        sources: {
+          'osm': {
+            type: 'raster',
+            tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+            tileSize: 256,
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          }
+        },
+        layers: [{
+          id: 'osm-tiles',
+          type: 'raster',
+          source: 'osm',
+          minzoom: 0,
+          maxzoom: 19
+        }]
+      },
+      center: [lon, lat],
+      zoom: 15
+    });
+
+    new maplibregl.Marker()
+      .setLngLat([lon, lat])
+      .addTo(this.map);
+  }
+}

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -13,9 +13,6 @@ export default class extends Controller {
 
   connect() {
     this.initMap()
-    if (!this.singlePointValue) {
-      this.applyFilters()
-    }
   }
 
   initMap() {
@@ -82,6 +79,11 @@ export default class extends Controller {
         this.map.on('click', 'data-layer', this.handleMarkerClick.bind(this));
         this.map.on('mouseenter', 'data-layer', () => this.map.getCanvas().style.cursor = 'pointer');
         this.map.on('mouseleave', 'data-layer', () => this.map.getCanvas().style.cursor = '');
+
+        // Apply filters after data is loaded
+        if (!this.singlePointValue) {
+          this.applyFilters()
+        }
       });
   }
 
@@ -117,6 +119,11 @@ export default class extends Controller {
   }
 
   applyFilters() {
+    if (!this.map.getLayer('data-layer')) {
+      console.warn('Data layer not yet loaded. Skipping filter application.');
+      return;
+    }
+
     const filters = Object.entries(this.filterGroupsValue).map(([groupName, options]) => {
       const checkedOptions = this.filterCheckboxTargets
         .filter(checkbox => checkbox.dataset.mapFilterGroup === groupName && checkbox.checked)
@@ -125,9 +132,7 @@ export default class extends Controller {
     });
 
     const combinedFilter = ['all', ...filters];
-    if (this.map) {
-      this.map.setFilter('data-layer', combinedFilter);
-    }
+    this.map.setFilter('data-layer', combinedFilter);
   }
 
   resetFilters() {

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -1,0 +1,124 @@
+import { Controller } from "@hotwired/stimulus"
+import maplibregl from 'maplibre-gl'
+
+export default class extends Controller {
+  static targets = ["mapContainer", "filters", "filterCheckbox", "popupTemplate"]
+  static values = {
+    initialLat: Number,
+    initialLon: Number,
+    dataUrl: String,
+    filterGroups: Object
+  }
+
+  connect() {
+    this.initMap()
+    this.applyFilters()
+  }
+
+  initMap() {
+    this.map = new maplibregl.Map({
+      container: this.mapContainerTarget,
+      style: {
+        version: 8,
+        sources: {
+          'osm': {
+            type: 'raster',
+            tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+            tileSize: 256,
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          }
+        },
+        layers: [{
+          id: 'osm-tiles',
+          type: 'raster',
+          source: 'osm',
+          minzoom: 0,
+          maxzoom: 19
+        }]
+      },
+      center: [this.initialLonValue, this.initialLatValue],
+      zoom: 13
+    });
+
+    this.map.on('load', () => this.loadData());
+  }
+
+  loadData() {
+    fetch(this.dataUrlValue)
+      .then(response => response.json())
+      .then(data => {
+        this.map.addSource('data-source', {
+          type: 'geojson',
+          data: data
+        });
+
+        this.map.addLayer({
+          'id': 'data-layer',
+          'type': 'circle',
+          'source': 'data-source',
+          'paint': {
+            'circle-radius': 6,
+            'circle-color': '#FFA500',
+            'circle-stroke-width': 2,
+            'circle-stroke-color': '#ffffff'
+          }
+        });
+
+        this.map.on('click', 'data-layer', this.handleMarkerClick.bind(this));
+        this.map.on('mouseenter', 'data-layer', () => this.map.getCanvas().style.cursor = 'pointer');
+        this.map.on('mouseleave', 'data-layer', () => this.map.getCanvas().style.cursor = '');
+      });
+  }
+
+  handleMarkerClick(e) {
+    const coordinates = e.features[0].geometry.coordinates.slice();
+    const properties = e.features[0].properties;
+
+    const popupContent = this.generatePopupContent(properties);
+
+    new maplibregl.Popup()
+      .setLngLat(coordinates)
+      .setHTML(popupContent)
+      .addTo(this.map);
+  }
+
+  generatePopupContent(properties) {
+    const template = this.popupTemplateTarget.cloneNode(true);
+    template.style.display = 'block';
+
+    const appNumberEl = template.querySelector('[data-map-popup-target="appNumber"]');
+    const appTypeEl = template.querySelector('[data-map-popup-target="appType"]');
+    const statusEl = template.querySelector('[data-map-popup-target="status"]');
+    const descriptionEl = template.querySelector('[data-map-popup-target="description"]');
+    const viewDetailsEl = template.querySelector('[data-map-popup-target="viewDetails"]');
+
+    appNumberEl.textContent = properties.app_number;
+    appTypeEl.textContent = properties.app_type;
+    statusEl.textContent = properties.status;
+    descriptionEl.textContent = properties.description;
+    viewDetailsEl.href = properties.url;
+
+    return template.innerHTML;
+  }
+
+  applyFilters() {
+    const filters = Object.entries(this.filterGroupsValue).map(([groupName, options]) => {
+      const checkedOptions = this.filterCheckboxTargets
+        .filter(checkbox => checkbox.dataset.mapFilterGroup === groupName && checkbox.checked)
+        .map(checkbox => checkbox.dataset.mapFilterOption);
+      return ['in', ['get', groupName], ['literal', checkedOptions]];
+    });
+
+    const combinedFilter = ['all', ...filters];
+    if (this.map) {
+      this.map.setFilter('data-layer', combinedFilter);
+    }
+  }
+
+  resetFilters() {
+    this.filterCheckboxTargets.forEach(checkbox => {
+      checkbox.checked = true;
+    });
+    this.applyFilters();
+  }
+}

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -7,12 +7,15 @@ export default class extends Controller {
     initialLat: Number,
     initialLon: Number,
     dataUrl: String,
-    filterGroups: Object
+    filterGroups: Object,
+    singlePoint: Boolean
   }
 
   connect() {
     this.initMap()
-    this.applyFilters()
+    if (!this.singlePointValue) {
+      this.applyFilters()
+    }
   }
 
   initMap() {
@@ -37,10 +40,22 @@ export default class extends Controller {
         }]
       },
       center: [this.initialLonValue, this.initialLatValue],
-      zoom: 13
+      zoom: this.singlePointValue ? 15 : 13
     });
 
-    this.map.on('load', () => this.loadData());
+    this.map.on('load', () => {
+      if (this.singlePointValue) {
+        this.addSingleMarker()
+      } else {
+        this.loadData()
+      }
+    });
+  }
+
+  addSingleMarker() {
+    new maplibregl.Marker()
+      .setLngLat([this.initialLonValue, this.initialLatValue])
+      .addTo(this.map);
   }
 
   loadData() {

--- a/app/models/coordinates.rb
+++ b/app/models/coordinates.rb
@@ -1,0 +1,16 @@
+class Coordinates
+  def initialize(lat, lon, precision: 5)
+    @precision = precision
+    @full_lat = lat
+    @full_lon = lon
+    # Accuracy  | DD.dddddd° Decimal places
+    # 10m       | 4
+    # 1m        | 5
+    # 0.1m      | 6
+    # https://wiki.openstreetmap.org/wiki/Precision_of_coordinates
+    @lat = lat.round(precision)
+    @lon = lon.round(precision)
+  end
+
+  attr_reader :lat, :lon, :full_lat, :full_lon, :precision
+end

--- a/app/models/dev_app/address.rb
+++ b/app/models/dev_app/address.rb
@@ -1,3 +1,7 @@
 class DevApp::Address < ApplicationRecord
   belongs_to :entry, class_name: "DevApp::Entry"
+
+  def coordinates
+    Coordinates.new(lat, lon)
+  end
 end

--- a/app/views/devapp/_map_popup.html.erb
+++ b/app/views/devapp/_map_popup.html.erb
@@ -1,0 +1,14 @@
+<div data-map-target="popupTemplate" style="display: none;">
+  <div class="card border-0">
+
+    <div class="card-body p-0">
+      <h5 class="card-title" data-map-popup-target="appNumber"></h5>
+      <h6 class="card-subtitle mb-2 text-muted" data-map-popup-target="appType"></h6>
+      <p class="card-text mb-1">
+        <span class="badge bg-secondary" data-map-popup-target="status"></span>
+      </p>
+      <p class="card-text mb-1" data-map-popup-target="description"></p>
+      <a href="#" class="card-link" data-map-popup-target="viewDetails">View Details</a>
+    </div>
+  </div>
+</div>

--- a/app/views/devapp/index.html.erb
+++ b/app/views/devapp/index.html.erb
@@ -7,33 +7,26 @@
     </div>
   </div>
 
-  <%
-  @devapps.each do |d|
-    %>
-    <p>
-    <%= link_to(d.app_number, "/devapp/#{d.app_number}") %>
-    <%= d.app_type %>: <%= d.desc %>.
-      <ul>
-      <% d.addresses.each do |a| %>
-        <% next if a.ref_id == "" %>
-        <li
-          class="devapp-address-list-item"
-          data-devapp-id="<%= d.id %>"
-          data-devapp-number="<%= d.app_number %>"
-          data-latitude="<%= a.lat %>"
-          data-longitude="<%= a.lon %>"
-        >
-        <%= [a.road_number, a.road_name, a.direction, a.road_type].compact.join(" ") %>
-        </li>
-      <% end %>
-      </ul>
-    </p>
-    <hr/>
-    <%
-  end
-  %>
+  <div class="list-group list-group-flush">
+    <% @devapps.each do |d| %>
+      <div class="list-group-item">
+        <div class="d-flex w-100 justify-content-between">
+          <%= link_to "/devapp/#{d.app_number}" do %>
+            <h5 class="mb-1"><%= d.app_number %></h5>
+          <% end %>
+          <small><%= d.updated_at.strftime("%B %d, %Y") %></small>
+        </div>
+        <p class="mb-1"><strong><%= d.app_type %></strong></p>
+        <p class="mb-1"><%= d.desc %></p>
+        <small>
+          Addresses:
+          <%= d.addresses.reject { |a| a.ref_id.blank? }.map { |a| [a.road_number, a.road_name, a.direction, a.road_type].compact.join(" ") }.join(", ") %>
+        </small>
+      </div>
+    <% end %>
+  </div>
 
-  <center>
-  <%= link_to "More...", devapp_index_path(before_id: @devapps.last&.id) %>
-  </center>
+  <div class="d-flex justify-content-center mt-4 mb-5">
+    <%= link_to "Load More", devapp_index_path(before_id: @devapps.last&.id), class: "btn btn-outline-primary" %>
+  </div>
 </div>

--- a/app/views/devapp/index.html.erb
+++ b/app/views/devapp/index.html.erb
@@ -1,31 +1,39 @@
-<h1>Development Applications</h1>
+<div class="container-fluid">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Development Applications</h1>
+    <div class="btn-group" role="group" aria-label="View toggle">
+      <%= link_to "List", devapp_index_path, class: "btn btn-outline-primary active" %>
+      <%= link_to "Map", devapp_map_path, class: "btn btn-outline-primary" %>
+    </div>
+  </div>
 
-<% 
-@devapps.each do |d| 
+  <%
+  @devapps.each do |d|
+    %>
+    <p>
+    <%= link_to(d.app_number, "/devapp/#{d.app_number}") %>
+    <%= d.app_type %>: <%= d.desc %>.
+      <ul>
+      <% d.addresses.each do |a| %>
+        <% next if a.ref_id == "" %>
+        <li
+          class="devapp-address-list-item"
+          data-devapp-id="<%= d.id %>"
+          data-devapp-number="<%= d.app_number %>"
+          data-latitude="<%= a.lat %>"
+          data-longitude="<%= a.lon %>"
+        >
+        <%= [a.road_number, a.road_name, a.direction, a.road_type].compact.join(" ") %>
+        </li>
+      <% end %>
+      </ul>
+    </p>
+    <hr/>
+    <%
+  end
   %>
-  <p>
-  <%= link_to(d.app_number, "/devapp/#{d.app_number}") %>
-  <%= d.app_type %>: <%= d.desc %>.
-    <ul>
-    <% d.addresses.each do |a| %>
-      <% next if a.ref_id == "" %>
-      <li
-        class="devapp-address-list-item"
-        data-devapp-id="<%= d.id %>"
-        data-devapp-number="<%= d.app_number %>"
-        data-latitude="<%= a.lat %>"
-        data-longitude="<%= a.lon %>"
-      >
-      <%= [a.road_number, a.road_name, a.direction, a.road_type].compact.join(" ") %>
-      </li>
-    <% end %>
-    </ul>
-  </p>
-  <hr/>
-  <% 
-end
-%>
 
-<center>
-<%= link_to "More...", devapp_index_path(before_id: @devapps.last&.id) %>
-</center>
+  <center>
+  <%= link_to "More...", devapp_index_path(before_id: @devapps.last&.id) %>
+  </center>
+</div>

--- a/app/views/devapp/map.html.erb
+++ b/app/views/devapp/map.html.erb
@@ -1,0 +1,54 @@
+<div class="container-fluid" data-controller="map"
+     data-map-initial-lat-value="<%= @initial_lat %>"
+     data-map-initial-lon-value="<%= @initial_lon %>"
+     data-map-data-url-value="<%= devapp_map_data_path %>"
+     data-map-filter-groups-value="<%= { status: @statuses, app_type: @app_types }.to_json %>">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Development Applications</h1>
+    <div class="btn-group" role="group" aria-label="View toggle">
+      <%= link_to "List", devapp_index_path, class: "btn btn-outline-primary" %>
+      <%= link_to "Map", devapp_map_path, class: "btn btn-outline-primary active" %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-3 mb-4">
+      <div class="card">
+        <div class="card-header">
+          <h5 class="card-title mb-0">Filters</h5>
+        </div>
+        <div class="card-body">
+          <div data-map-target="filters">
+            <% { status: @statuses, app_type: @app_types }.each do |group_name, options| %>
+              <div class="mb-3">
+                <h6><%= group_name.to_s.titleize %></h6>
+                <% options.each do |option| %>
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="filter-<%= group_name %>-<%= option %>"
+                           data-map-target="filterCheckbox"
+                           data-action="change->map#applyFilters"
+                           data-map-filter-group="<%= group_name %>"
+                           data-map-filter-option="<%= option %>"
+                           checked>
+                    <label class="form-check-label" for="filter-<%= group_name %>-<%= option %>">
+                      <%= option %>
+                    </label>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+            <button class="btn btn-sm btn-outline-secondary mt-3" data-action="click->map#resetFilters">
+              Reset Filters
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-9">
+      <div data-map-target="mapContainer" style="width: 100%; height: 600px;"></div>
+    </div>
+  </div>
+
+  <%= render partial: 'map_popup' %>
+</div>
+

--- a/app/views/devapp/show.html.erb
+++ b/app/views/devapp/show.html.erb
@@ -1,69 +1,96 @@
 <% content_for(:html_title, "#{@entry.app_number} - Development Application") %>
-<h1><%= @entry.app_number %></h1>
-<table border="1">
-<tr><th>Number</th><td><%= @entry.app_number %></td></tr>
-<tr><th>Type</th><td><%= @entry.app_type %></td></tr>
-<tr><th>Indexed</th><td><%= @entry.created_at %></td></tr>
-<tr><th>Description</th><td><%= @entry.desc %></td></tr>
-<tr><th>External</th><td><%= link_to("View application on ottawa.ca", "https://devapps.ottawa.ca/en/applications/#{@entry.app_number}/details") %></td></tr>
 
-<tr>
-  <th>Status</th>
-  <td>
-    <ul>
-    <%
-    @entry.statuses.each do |a|
-      %>
-      <li><%= a.slice(:created_at, :status).values.join(" ") %></li>
-      <%
-    end
-    %>
-    </ul>
-  </td>
-</tr>
-<tr>
-  <th>Addresses</th>
-  <td>
-    <ul>
-    <%
-    @entry.addresses.each do |a|
-      %>
-      <li><%= a.slice(:road_number, :road_name, :road_type, :direction, :municipality).values.join(" ") %></li>
-      <%
-    end
-    %>
-    </ul>
-  </td>
-</tr>
-<tr>
-  <th>City Staff Contact</th>
-  <td>
-    <%= @entry.planner_first_name %> <%= @entry.planner_last_name %><br/>
-    <a href="mailto:<%= @entry.planner_email %>"><%= @entry.planner_email %></a><br/>
-    <a href="tel:<%= @entry.planner_phone %>"><%= @entry.planner_phone %></a><br/>
-  </td>
-</tr>
-<tr>
-  <th>Documents</th>
-  <td>
-    <ul>
-    <%
-    @entry.documents.each do |d|
-      %>
-      <li>
-      <%= link_to(d.name.gsub(@entry.app_number, " "), d.url) %>
-      <%
-      if !%w(200 302).include?(d.state)
-        %>
-        (<span style="color: #ff0000">Missing/broken document: <%= d.state %></span>)
-        <%
-      end
-      %>
-      </li>
-      <%
-    end
-    %>
-    </ul>
-  </td>
-</tr>
-</table>
+<div class="container mt-4" data-controller="devapp-show">
+  <h1 class="mb-4"><%= @entry.app_number %></h1>
+
+  <div class="row">
+    <div class="col-md-8">
+      <div class="card mb-4">
+        <div class="card-body">
+          <h5 class="card-title">Application Details</h5>
+          <dl class="row">
+            <dt class="col-sm-3">Number</dt>
+            <dd class="col-sm-9"><%= @entry.app_number %></dd>
+
+            <dt class="col-sm-3">Type</dt>
+            <dd class="col-sm-9"><%= @entry.app_type %></dd>
+
+            <dt class="col-sm-3">Indexed</dt>
+            <dd class="col-sm-9"><%= @entry.created_at.strftime("%B %d, %Y") %></dd>
+
+            <dt class="col-sm-3">Description</dt>
+            <dd class="col-sm-9"><%= @entry.desc %></dd>
+
+            <dt class="col-sm-3">External Link</dt>
+            <dd class="col-sm-9">
+              <%= link_to("View application on ottawa.ca", "https://devapps.ottawa.ca/en/applications/#{@entry.app_number}/details", target: "_blank", class: "btn btn-sm btn-outline-primary") %>
+            </dd>
+          </dl>
+        </div>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-body">
+          <h5 class="card-title">Status History</h5>
+          <ul class="list-group list-group-flush">
+            <% @entry.statuses.each do |status| %>
+              <li class="list-group-item">
+                <strong><%= status.created_at.strftime("%B %d, %Y") %>:</strong> <%= status.status %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-body">
+          <h5 class="card-title">Addresses</h5>
+          <ul class="list-group list-group-flush">
+            <% @entry.addresses.each do |address| %>
+              <li class="list-group-item">
+                <%= [address.road_number, address.road_name, address.road_type, address.direction, address.municipality].compact.join(" ") %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-body">
+          <h5 class="card-title">City Staff Contact</h5>
+          <p class="card-text">
+            <%= @entry.planner_first_name %> <%= @entry.planner_last_name %><br>
+            <a href="mailto:<%= @entry.planner_email %>"><%= @entry.planner_email %></a><br>
+            <a href="tel:<%= @entry.planner_phone %>"><%= @entry.planner_phone %></a>
+          </p>
+        </div>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-body">
+          <h5 class="card-title">Documents</h5>
+          <ul class="list-group list-group-flush">
+            <% @entry.documents.each do |document| %>
+              <li class="list-group-item">
+                <%= link_to(document.name.gsub(@entry.app_number, "").strip, document.url, target: "_blank") %>
+                <% unless %w(200 302).include?(document.state) %>
+                  <span class="badge bg-danger">Missing/broken document: <%= document.state %></span>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-4">
+      <div data-controller="map"
+          data-map-target="mapContainer"
+          data-map-initial-lat-value="<%= @entry.addresses.first&.coordinates&.lat %>"
+          data-map-initial-lon-value="<%= @entry.addresses.first&.coordinates&.lon %>"
+          data-map-single-point-value="true"
+          class="rounded"
+          style="width: 100%; height: 300px;"></div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
     <%= javascript_importmap_tags %>
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <link href='https://unpkg.com/maplibre-gl@3.3.1/dist/maplibre-gl.css' rel='stylesheet' />
     <%= auto_discovery_link_tag :rss, "https://ottwatch.ca/home/index.rss" %>
 
     <style>
@@ -77,7 +78,7 @@
 
       <div class="row ow_footer" style="">
         <div class="col-6">
-          <%= image_tag "logo_50.png" %> 
+          <%= image_tag "logo_50.png" %>
         </div>
         <div class="col-6" style="text-align: right;">
           By <a href="https://kevino.ca">Kevin O'Donnell</a><br/>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,3 +5,4 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
+pin "maplibre-gl", to: "https://ga.jspm.io/npm:maplibre-gl@3.3.1/dist/maplibre-gl.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,10 @@ Rails.application.routes.draw do
 
   get 'parcels/:id', to: 'parcels#show'
 
+  get 'devapp/map', to: 'devapp#map'
+  get 'devapp/map_data', to: 'devapp#map_data'
   get 'devapp/index'
-  get 'devapp/:app_number', to: 'devapp#show'
+  get 'devapp/:app_number', to: 'devapp#show', as: 'devapp'
 
   get 'lobbying/index'
   get 'lobbying/:id', to: 'lobbying#show'

--- a/test/models/coordinates_test.rb
+++ b/test/models/coordinates_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class CoordinatesTest < ActiveSupport::TestCase
+  test "lat and lon are rounded to 5 decimal places for meter precision by default" do
+    coordinates = Coordinates.new(45.420906, -75.689374)
+    assert_equal 45.42091, coordinates.lat
+    assert_equal -75.68937, coordinates.lon
+  end
+
+  test "lat and lon are rounded to the specified precision" do
+    coordinates = Coordinates.new(45.420906, -75.689374, precision: 2)
+    assert_equal 45.42, coordinates.lat
+    assert_equal -75.69, coordinates.lon
+  end
+
+  test "full_lat and full_lon are the original values" do
+    coordinates = Coordinates.new(45.420906, -75.689374)
+    assert_equal 45.420906, coordinates.full_lat
+    assert_equal -75.689374, coordinates.full_lon
+  end
+end


### PR DESCRIPTION
I thought it would be neat to be able to display the development applications on a map. This makes it easier for folks to find developments in areas they are about. (I already found the one at Pimisi I keep seeing on my run and thinking _"I must look that up when I get home"_ and never do) 😁 

- Adds a Map View using https://maplibre.org/ an open-source JavaScript library that utilizes WebGL to render interactive maps from vector tiles, allowing for dynamic and customizable mapping experiences in web applications.
- Adds support for filtering the map by app type and (latest) status. 
   - The map view and filtering have been built in a generic way so that we can use them in other areas (they're not uniquely built for dev apps).  
   - It's built using Hotwire Stimulus.
- Updated the dev apps `show` page to render the map (along side revamped details UI). 
- Updated the dev apps `index` page UI to be a more consistent with the newly updated `show` page.
- Added a "toggle" button to the pages so that you can swap between the "list" and "map" views. 


https://github.com/user-attachments/assets/290baeda-3a1a-47c3-b8a3-7a2d1bef24ef


