### PR TITLE
Revert "Bump sidekiq from 6.5.12 to 7.3.5"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem "mini_magick", "~> 4.12"
 
 gem "google-cloud-storage", require: false
 #gem "sidekiq"
-gem 'sidekiq', '<8'
+gem 'sidekiq', '<7'
 gem "sidekiq-cron"
 gem "xsv"
 gem "twitter"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,8 +343,7 @@ GEM
     rake (13.2.1)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
-    redis-client (0.22.2)
-      connection_pool
+    redis (4.8.1)
     regexp_parser (2.9.0)
     reline (0.5.1)
       io-console (~> 0.5)
@@ -384,11 +383,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sidekiq (7.3.5)
-      connection_pool (>= 2.3.0)
-      logger
-      rack (>= 2.2.4)
-      redis-client (>= 0.22.2)
+    sidekiq (6.5.12)
+      connection_pool (>= 2.2.5, < 3)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     sidekiq-cron (1.12.0)
       fugit (~> 1.8)
       globalid (>= 1.0.1)
@@ -498,7 +496,7 @@ DEPENDENCIES
   rmagick
   rubocop
   selenium-webdriver
-  sidekiq (< 8)
+  sidekiq (< 7)
   sidekiq-cron
   spring
   sprockets-rails


### PR DESCRIPTION
Reverts kevinodotnet/ottwatch#167

2024-11-12T03:20:18.182Z pid=1 tid=dx1 WARN: NoMethodError: undefined method `perform_async' for #<ActiveJob::ConfiguredJob:0x057e2dd0 @options={:queue=>"default"}, @job_class=TrafficCameraScrapeJob>