### PR TITLE
create solid_cable_messages table

### DIFF
--- a/db/migrate/20250222190338_create_solid_cable_tables.rb
+++ b/db/migrate/20250222190338_create_solid_cable_tables.rb
@@ -1,0 +1,13 @@
+class CreateSolidCableTables < ActiveRecord::Migration[8.0]
+  def change
+    create_table "solid_cable_messages", force: :cascade do |t|
+      t.binary "channel", limit: 1024, null: false
+      t.binary "payload", limit: 536870912, null: false
+      t.datetime "created_at", null: false
+      t.integer "channel_hash", limit: 8, null: false
+      t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+      t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
+      t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_06_165929) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_22_190338) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -281,6 +281,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_06_165929) do
     t.string "media_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "solid_cable_messages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.binary "channel", limit: 1024, null: false
+    t.binary "payload", size: :long, null: false
+    t.datetime "created_at", null: false
+    t.bigint "channel_hash", null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
   end
 
   create_table "traffic_cameras", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/db/v1_schema.rb
+++ b/db/v1_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_06_165929) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_22_190338) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -281,6 +281,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_06_165929) do
     t.string "media_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "solid_cable_messages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.binary "channel", limit: 1024, null: false
+    t.binary "payload", size: :long, null: false
+    t.datetime "created_at", null: false
+    t.bigint "channel_hash", null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
   end
 
   create_table "traffic_cameras", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
By default `solid_cable` does not create a migration. Standard rails migration to create the table as defined in `db/cable_schema.rb` which is simply copied over