### PR TITLE
Schedule jobs

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -43,3 +43,4 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -9,6 +9,28 @@
 #     priority: 2
 #     schedule: at 5am every day
 
+production:
+  dev_app_scan_job:
+    class: "DevAppScanJob"
+    schedule: "30 10-20 * * *"
+  lobbying_scan_job:
+    class: "LobbyingScanJob"
+    schedule: "45 10-20 * * *"
+  meeting_scan_job:
+    class: "MeetingScanJob"
+    schedule: "0 6,10,14,16,20 * * *"
+  parcel_scanner:
+    class: "ParcelScanner"
+    schedule: "0 2 1,2,3 * *"
+  zoning_scanner:
+    class: "ZoningScanner"
+    schedule: "0 2 1,2,3 * *"
+  consultation_scanner:
+    class: "ConsultationScanner"
+    schedule: "10 10-20 * * *"
+  traffic_camera_scrape_job:
+    schedule: "*/5 * * * *"
+
 
 #################################
 ### OLD SIDEKIQ JOB SCHEDULES ###

--- a/docker/prod-web.sh
+++ b/docker/prod-web.sh
@@ -16,6 +16,7 @@ sudo docker run \
   -e DB_NAME_V1=$DB_NAME_V1 \
   -e DB_PASS=$DB_PASS \
   -e DB_USER=$DB_USER \
+  -e SOLID_QUEUE_IN_PUMA=1 \
   -e GCS_KEYFILE=/infra/gcs-prodweb-service-account.json \
   -e GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY \
   -e GOOGLE_WEB_APP_CLIENT_ID=$GOOGLE_WEB_APP_CLIENT_ID \


### PR DESCRIPTION
Per https://github.com/rails/solid_queue instructions: 

- schedule the jobs
- run the scheduler (and forked workers) via puma; so no need for an additional docker container to deploy/manage