### PR TITLE
get full consultation title when parsing

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -3,7 +3,7 @@ class Announcement < ApplicationRecord
 
   def reference_context
     if reference.is_a?(Consultation)
-      reference.title
+      return reference.title
     end
     if reference.is_a?(DevApp::Entry)
       if addr = reference.addresses.first

--- a/app/models/consultation_scanner.rb
+++ b/app/models/consultation_scanner.rb
@@ -25,7 +25,8 @@ class ConsultationScanner < ApplicationJob
       next unless d.attributes["class"]&.value
       next unless d.attributes["class"]&.value.split(" ").include?("project-tile")
       tile = Nokogiri::HTML(d.to_s)
-      title = tile.xpath('//div[@class="project-tile__meta"]/span[@class="project-tile__meta__name"]').first.children.first.to_s
+      title = tile.xpath("//body/div").first.attributes["data-name"].value.humanize
+      title = title.split.map(&:capitalize).join(' ')
       href = tile.xpath('//a[@class="project-tile__link"]').first.attributes["href"].value
       status = d.attributes["data-state"].value
       {

--- a/test/models/consultation_scanner_test.rb
+++ b/test/models/consultation_scanner_test.rb
@@ -9,10 +9,10 @@ class ConsultationScannerTest < ActiveSupport::TestCase
 
       # cherry pick attr tests
       c = Consultation.find_by_href("/beryl-gaffney-off-leash-dog-park")
-      assert_equal "Beryl Gaffney Off-Leash Dog Park", c.title
+      assert_equal "Beryl Gaffney Off-leash Dog Park", c.title
       assert_equal "archived", c.status
       assert_equal 1, c.announcements.count
-      expected = "New Consultation: Beryl Gaffney Off-Leash Dog Park"
+      expected = "New Consultation: Beryl Gaffney Off-leash Dog Park"
       assert_equal expected, c.announcements.first.message
 
       # confirm only two known states


### PR DESCRIPTION
Fixes https://github.com/kevinodotnet/ottwatch/issues/206

Turns out the full title was already in the extracted data, just as a hidden data node. Extract that and then "humanize" it. Not perfect, as some of the capitalization will be off, but ... this is way better

```
[5] pry(#<ConsultationScanner>)> tile.xpath("//body/div").first
=> #(Element:0x5564 {
  name = "div",
  attribute_nodes = [
    #(Attr:0x5578 { name = "class", value = "col-xs-12 col-sm-6 col-lg-3 project-tile" }),
    #(Attr:0x558c { name = "data-name", value = "trail waste facility optimization - environmental assessment" }),
    #(Attr:0x55a0 { name = "data-state", value = "published" })],
```