### PR TITLE
handle html requests from bots

### DIFF
--- a/app/controllers/traffic_cameras_controller.rb
+++ b/app/controllers/traffic_cameras_controller.rb
@@ -13,7 +13,14 @@ class TrafficCamerasController < ApplicationController
     @traffic_camera = TrafficCamera.find(params[:id])
     capture = @traffic_camera.captures.detect{|c| c[:time_ms] == params[:time_ms].to_i}
     return unless capture
-    response.headers['Cache-Control'] = 'public, max-age=86400'
-    send_data(File.read(capture[:file]), type: 'image/jpeg', disposition: 'inline', filename: "cam_#{params[:id]}_#{params[:time_ms]}.jpg")
+    
+    respond_to do |format|
+      format.jpeg do
+        response.headers['Cache-Control'] = 'public, max-age=86400'
+        send_data(File.read(capture[:file]), type: 'image/jpeg', disposition: 'inline', filename: "cam_#{params[:id]}_#{params[:time_ms]}.jpg")
+      end
+      format.html { redirect_to traffic_camera_path(@traffic_camera) }
+      format.any { head :not_acceptable }
+    end
   end
 end


### PR DESCRIPTION
Fixes bots hitting the URL for HTML content and having an error reported for it

<img width="1064" height="834" alt="image" src="https://github.com/user-attachments/assets/a42fc914-1319-4fc2-8a21-d63ba1864f9f" />
